### PR TITLE
validate schemespal input

### DIFF
--- a/frontend/static/js/events.js
+++ b/frontend/static/js/events.js
@@ -1,4 +1,10 @@
 function handle__schemespal() {
+    const input = document.getElementById("text-input")
+    if (!input.checkValidity()) {
+        input.reportValidity();
+        return;
+    }
+
     //Google
     const scriptURLpalquery = 'https://script.google.com/macros/s/AKfycbwgKnPhUBHnlGJ3YudlSeaMfjUe9mPaI-N3Sbz9uar52oDDFf0/exec'
     const schemespalform = document.getElementById("schemespal")

--- a/frontend/static/js/indexpal.js
+++ b/frontend/static/js/indexpal.js
@@ -1,4 +1,9 @@
 function handle_indexpal() {
+    const input = document.getElementById("indexpal-text")
+    if (!input.checkValidity()) {
+        input.reportValidity();
+        return;
+    }
 
     const scriptURLindexpal = 'https://script.google.com/macros/s/AKfycbwgKnPhUBHnlGJ3YudlSeaMfjUe9mPaI-N3Sbz9uar52oDDFf0/exec'
     const indexpalform = document.getElementById("indexpal")


### PR DESCRIPTION
fixes #24 

validates schemespal input through frontend. this change only checks for empty string but maybe ascii pattern is better.  

previously, backend will accept empty string and throw the following error:
```
  File "/Users/home/Desktop/SchemesSG_v3/.venv/lib/python3.12/site-packages/numpy/lib/function_base.py", line 4835, in _quantile
    previous = arr[previous_indexes]
               ~~~^^^^^^^^^^^^^^^^^^
IndexError: index -1 is out of bounds for axis 0 with size 0
```

<img width="606" alt="Screenshot 2024-08-22 at 6 42 34 PM" src="https://github.com/user-attachments/assets/300b8c9b-fdad-438f-9bb6-51bf564054c3">
<img width="606" alt="Screenshot 2024-08-22 at 6 48 24 PM" src="https://github.com/user-attachments/assets/06eb914f-a625-4640-866f-025774fddad6">
