### PR TITLE
73 chat styling

### DIFF
--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -13,12 +13,12 @@ export default function Home() {
         <main style={{ display: "flex", justifyContent: "center" }}>
             {
                 schemesResList.length > 0
-                ? <div style={{ display:"grid", gridTemplateColumns: "2fr 3fr", gap: "0.5rem"}}>
+                ? <div style={{ display:"grid", gridTemplateColumns: "2fr 3fr", gap: "1rem"}}>
                     <MainChat sessionId={sessionId}/>
                     <SchemesList schemes={schemesResList} />
                 </div>
-                :
-                <div style={{ width: "35rem" }}>
+                :   
+                <div>
                     <div style={{ width: "35rem", paddingBottom:"3rem" }}>
                         <div className="font-extrabold text-2xl" style={{ display:"flex", justifyContent: "center" }}>
                             <p style={{ color:"#171347" }}>Welcome to Schemes </p>

--- a/frontend/src/app/providers.tsx
+++ b/frontend/src/app/providers.tsx
@@ -11,16 +11,19 @@ export type Message = {
 
 type ChatContextType = {
   messages: Message[];
-  setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
+  setMessages: React.Dispatch<React.SetStateAction<Message[]>>,
+  userQuery: string,
+  setUserQuery: React.Dispatch<React.SetStateAction<string>>
 };
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
 
 export const ChatProvider = ({ children }: { children: ReactNode }) => {
   const [messages, setMessages] = useState<Message[]>([]);
+  const [userQuery, setUserQuery] = useState<string>("");
 
   return (
-    <ChatContext.Provider value={{ messages, setMessages }}>
+    <ChatContext.Provider value={{ messages, setMessages, userQuery, setUserQuery }}>
       {children}
     </ChatContext.Provider>
   );

--- a/frontend/src/components/chat-bar/chat-bar.module.css
+++ b/frontend/src/components/chat-bar/chat-bar.module.css
@@ -1,3 +1,7 @@
+.chatBar {
+    margin-top: auto;
+}
+
 .chatBar textarea::placeholder{
     font-style: italic;
     color: rgba(0, 0, 0, 0.2);

--- a/frontend/src/components/chat-bar/chat-bar.module.css
+++ b/frontend/src/components/chat-bar/chat-bar.module.css
@@ -1,5 +1,6 @@
 .chatBar {
     margin-top: auto;
+    z-index: 1;
 }
 
 .chatBar textarea::placeholder{

--- a/frontend/src/components/chat-bar/chat-bar.tsx
+++ b/frontend/src/components/chat-bar/chat-bar.tsx
@@ -22,6 +22,12 @@ export default function ChatBar({ userInput, setUserInput, handleUserInput, isBo
             <Textarea
                 value={userInput}
                 onChange={(e) => setUserInput(e.target.value)}
+                onKeyDown={async (e) => {
+                    if (e.key === "Enter" && !isBotResponseGenerating) {
+                        e.preventDefault();
+                        handleSend();
+                    }
+                }}
                 className={classes.chatBar}
                 type="text"
                 size="md"

--- a/frontend/src/components/chat-bar/chat-bar.tsx
+++ b/frontend/src/components/chat-bar/chat-bar.tsx
@@ -1,12 +1,13 @@
 import { Button, Spinner, Textarea } from "@nextui-org/react";
 import { SearchIcon } from '../../assets/icons/search-icon';
 import classes from './chat-bar.module.css';
+import { RefObject } from "react";
 
 interface ChatBarProps {
     userInput: string;
     setUserInput: React.Dispatch<React.SetStateAction<string>>;
     handleUserInput: (message: string) => void;
-    isBotResponseGenerating: boolean
+    isBotResponseGenerating: boolean;
 }
 
 export default function ChatBar({ userInput, setUserInput, handleUserInput, isBotResponseGenerating }: ChatBarProps) {

--- a/frontend/src/components/chat-list/chat-list.module.css
+++ b/frontend/src/components/chat-list/chat-list.module.css
@@ -3,11 +3,14 @@
     flex-direction: column;
     gap: 10px;
     padding: 16px;
+    overflow: hidden auto;
+    max-height: 68vh;
+    padding: 0.5rem;
 }
 
 .messageContainer {
     display: flex;
-    align-items: flex-start; 
+    align-items: flex-start;
 }
 
 .botContainer {

--- a/frontend/src/components/chat-list/chat-list.tsx
+++ b/frontend/src/components/chat-list/chat-list.tsx
@@ -2,16 +2,18 @@ import { Avatar, Card, CardBody } from "@nextui-org/react";
 import classes from "./chat-list.module.css"
 import ReactMarkdown from "react-markdown";
 import { Message } from "@/app/providers";
+import { RefObject } from "react";
 
 interface ChatListProps {
   messages: Message[];
   streamingMessage?: string;
+  scrollableDivRef: RefObject<HTMLDivElement>
 }
 
-export default function ChatList({ messages, streamingMessage }: ChatListProps) {
+export default function ChatList({ messages, streamingMessage, scrollableDivRef }: ChatListProps) {
 
   return (
-    <div className={classes.chatList}>
+    <div className={classes.chatList} ref={scrollableDivRef}>
         {messages.map((msg, index) => (
             <div key={index} className={`${classes.messageContainer} ${msg.type === "user" ? classes.userContainer : classes.botContainer}`}>
                 {msg.type === "bot" && (

--- a/frontend/src/components/main-chat/main-chat.module.css
+++ b/frontend/src/components/main-chat/main-chat.module.css
@@ -1,7 +1,9 @@
 .mainChat {
+    background: #FAFBFE;
+    border-radius: 2rem;
     margin: auto;
     width: 100%;
-    max-height: 40rem;
+    height: 100%;
     padding: 0.8rem;
     overflow-y: auto
 }

--- a/frontend/src/components/main-chat/main-chat.module.css
+++ b/frontend/src/components/main-chat/main-chat.module.css
@@ -1,6 +1,8 @@
 .mainChat {
+    display: flex;
+    flex-direction: column;
     background: #FAFBFE;
-    border-radius: 2rem;
+    border-radius: 1rem;
     margin: auto;
     width: 100%;
     height: 100%;

--- a/frontend/src/components/main-chat/main-chat.tsx
+++ b/frontend/src/components/main-chat/main-chat.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from "react";
+import { useRef, useState } from "react";
 import ChatList from "@/components/chat-list/chat-list";
 import ChatBar from "@/components/chat-bar/chat-bar";
 import { Spacer } from "@nextui-org/react";
@@ -19,6 +19,8 @@ export default function MainChat({ sessionId }: MainChatProps) {
     const [isBotResponseGenerating, setIsBotResponseGenerating] = useState<boolean>(false);
     const [currentStreamingMessage, setCurrentStreamingMessage] = useState("");
 
+    const scrollableDivRef = useRef<HTMLDivElement>(null);
+
     const handleUserInput = async (input: string) => {
         setMessages((prevMessages: Message[]) => [
             ...prevMessages,
@@ -27,6 +29,7 @@ export default function MainChat({ sessionId }: MainChatProps) {
         setUserInput("");
         // Trigger API call for bot response
         await fetchBotResponse(input);
+        handleScrollToBottom();
     };
 
     const handleBotResponse = (response: string) => {
@@ -96,10 +99,19 @@ export default function MainChat({ sessionId }: MainChatProps) {
       }
     };
 
+    const handleScrollToBottom = () => {
+        if (scrollableDivRef.current) {
+        scrollableDivRef.current.scrollTo({
+            top: scrollableDivRef.current.scrollHeight,
+            behavior: 'smooth',
+        });
+        }
+    };
+
     return (
         <div className={classes.mainChat}>
             <UserQuery />
-            <ChatList messages={messages} streamingMessage={currentStreamingMessage} />
+            <ChatList messages={messages} streamingMessage={currentStreamingMessage} scrollableDivRef={scrollableDivRef} />
             <Spacer y={4} />
             <ChatBar
                 userInput={userInput}

--- a/frontend/src/components/main-chat/main-chat.tsx
+++ b/frontend/src/components/main-chat/main-chat.tsx
@@ -6,6 +6,7 @@ import ChatBar from "@/components/chat-bar/chat-bar";
 import { Spacer } from "@nextui-org/react";
 import classes from "./main-chat.module.css"
 import { Message, useChat } from "@/app/providers";
+import UserQuery from "../user-query/user-query";
 
 type MainChatProps = {
   sessionId: string;
@@ -86,12 +87,6 @@ export default function MainChat({ sessionId }: MainChatProps) {
         }
         handleBotResponse(fullMessage);
 
-        // const data = await response.json();
-        // if (data.response) {
-        //   handleBotResponse(data.message);
-        // } else {
-        //   handleBotResponse("Sorry, something went wrong. Please try again.");
-        // }
       } catch (error) {
         console.error("Error fetching bot response:", error);
         handleBotResponse("Sorry, something went wrong. Please try again.");
@@ -103,6 +98,7 @@ export default function MainChat({ sessionId }: MainChatProps) {
 
     return (
         <div className={classes.mainChat}>
+            <UserQuery />
             <ChatList messages={messages} streamingMessage={currentStreamingMessage} />
             <Spacer y={4} />
             <ChatBar

--- a/frontend/src/components/main-chat/main-chat.tsx
+++ b/frontend/src/components/main-chat/main-chat.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import ChatList from "@/components/chat-list/chat-list";
 import ChatBar from "@/components/chat-bar/chat-bar";
 import { Spacer } from "@nextui-org/react";
@@ -21,6 +21,10 @@ export default function MainChat({ sessionId }: MainChatProps) {
 
     const scrollableDivRef = useRef<HTMLDivElement>(null);
 
+    useEffect(() => {
+      handleScrollToBottom();
+    }, [messages])
+
     const handleUserInput = async (input: string) => {
         setMessages((prevMessages: Message[]) => [
             ...prevMessages,
@@ -29,7 +33,6 @@ export default function MainChat({ sessionId }: MainChatProps) {
         setUserInput("");
         // Trigger API call for bot response
         await fetchBotResponse(input);
-        handleScrollToBottom();
     };
 
     const handleBotResponse = (response: string) => {

--- a/frontend/src/components/main-footer/main-footer.module.css
+++ b/frontend/src/components/main-footer/main-footer.module.css
@@ -1,5 +1,5 @@
 .footer {
-    margin-top: 1rem;
+    margin-top: 2rem;
     padding: 2em 6em;
     color: white;
     background-color: rgba(23, 19, 71, 1);

--- a/frontend/src/components/main-header/main-header.tsx
+++ b/frontend/src/components/main-header/main-header.tsx
@@ -36,9 +36,9 @@ export default function MainHeader() {
                 }}
             >
                 <NavbarBrand>
-                    <Link className={classes.logo} href="/">
+                    <a className={classes.logo} href="/">
                         <Image src={logoImg} alt="Schemes SG logo" width={120} height={30} priority/>
-                    </Link>
+                    </a>
                 </NavbarBrand>
                 <NavbarContent className="hidden sm:flex gap-4" justify="end">
                     {navbarItems.map((item, idx) => {

--- a/frontend/src/components/main-layout/main-layout.module.css
+++ b/frontend/src/components/main-layout/main-layout.module.css
@@ -1,9 +1,8 @@
 .contentWrapper {
-    padding: 2em 5em;
+    padding: 0.5em 5em;
     margin: 0 auto;
     max-width: 1500px;
-    max-height: 90vh;
-    height: 100vh;
+    height: 90vh;
     box-sizing: border-box;
     display: flex;
     flex-direction: column;

--- a/frontend/src/components/main-layout/main-layout.module.css
+++ b/frontend/src/components/main-layout/main-layout.module.css
@@ -1,5 +1,5 @@
 .contentWrapper {
-    padding: 0.5em 5em;
+    padding: 0.5em 4em;
     margin: 0 auto;
     max-width: 1500px;
     height: 90vh;

--- a/frontend/src/components/schemes/schemes-list.tsx
+++ b/frontend/src/components/schemes/schemes-list.tsx
@@ -25,7 +25,7 @@ interface SchemesListProps {
 export default function SchemesList({ schemes }: SchemesListProps) {
 
     return (
-        <div style={{ padding:"0.8rem" }}>
+        <div>
             <div>
                 <p className="text-base font-semibold">Search Results</p>
                 <p className="text-xs text-slate-500">Showing {schemes.length} schemes</p>

--- a/frontend/src/components/search-bar/search-bar.tsx
+++ b/frontend/src/components/search-bar/search-bar.tsx
@@ -32,15 +32,15 @@ const mapToScheme = (rawData: any): Scheme => {
 };
 
 export default function SearchBar({ setSchemeResList, setSessionId }: SearchBarProps) {
-    const { setMessages } = useChat();
+    const { setMessages, setUserQuery } = useChat();
     const [userInput, setUserInput] = useState("");
     const [isBotResponseGenerating, setIsBotResponseGenerating] = useState<boolean>(false);
 
     const handleUserInput = (input: string) => {
         setMessages([
-            { type: "bot", text: `Your query is: ${input}` },
             { type: "bot", text: "You can see the search results on the right. Please ask me any further questions about the schemes." }
         ]);
+        setUserQuery(input);
         setUserInput("");
     };
 

--- a/frontend/src/components/search-bar/search-bar.tsx
+++ b/frontend/src/components/search-bar/search-bar.tsx
@@ -96,6 +96,12 @@ export default function SearchBar({ setSchemeResList, setSessionId }: SearchBarP
             <Textarea
                 value={userInput}
                 onChange={(e) => setUserInput(e.target.value)}
+                onKeyDown={async (e) => {
+                    if (e.key === "Enter" && !isBotResponseGenerating) {
+                        e.preventDefault();
+                        await handleSend();
+                    }
+                }}
                 className={classes.searchBar}
                 type="text"
                 size="md"

--- a/frontend/src/components/user-query/user-query.module.css
+++ b/frontend/src/components/user-query/user-query.module.css
@@ -1,0 +1,16 @@
+.userQuery {
+    background: #E8ECFF;
+    margin: 0.5rem;
+    font-size: 0.875rem;
+}
+
+.card {
+    width: 95%;
+    padding: 3px;
+    border-radius: 16px;
+    line-height: 1.25rem;
+}
+
+.cardBody {
+    padding: 4px 8px;
+}

--- a/frontend/src/components/user-query/user-query.tsx
+++ b/frontend/src/components/user-query/user-query.tsx
@@ -1,0 +1,20 @@
+import { Card, CardBody } from "@nextui-org/card";
+import classes from './user-query.module.css';
+import { useChat } from "@/app/providers";
+
+export default function UserQuery() {
+    const { userQuery } = useChat();
+
+    return (
+        <Card
+            className={`${classes.card} ${classes.userQuery}`}
+            fullWidth={false}
+            radius="lg"
+            shadow="none"
+        >
+            <CardBody className={`${classes.cardBody}`}>
+                Your query is: <b>{userQuery}</b>
+            </CardBody>
+        </Card>
+    )
+}


### PR DESCRIPTION
**please review the `74_misc_frontend` branch and merge before reviewing this branch.** this branch was stacked on top of `74_misc_frontend` branch.

scope:
- stick search query at the top of chat
- chat bar should remain at the bottom (ref chatgpt)
- pressing enter button should send chat input
- scroll to bottom of chat list when user submits new chat item & when bot finishes generating response	