### PR TITLE
refactor: replace json.dumps with safe_json_dumps for response handling

### DIFF
--- a/backend/functions/chat/chat.py
+++ b/backend/functions/chat/chat.py
@@ -14,6 +14,7 @@ from loguru import logger
 from ml_logic import Chatbot, dataframe_to_text
 from utils.cors_config import get_cors_headers, handle_cors_preflight
 from utils.auth import verify_auth_token
+from utils.json_utils import safe_json_dumps
 
 
 # Remove default handler
@@ -109,7 +110,7 @@ def chat_message(req: https_fn.Request) -> https_fn.Response:
     except Exception as e:
         logger.exception("Unable to fetch user query from firestore", e)
         return https_fn.Response(
-            response=json.dumps({"error": "Internal server error, unable to fetch user query from firestore"}),
+            response=safe_json_dumps({"error": "Internal server error, unable to fetch user query from firestore"}),
             status=500,
             mimetype="application/json",
             headers=headers,
@@ -185,10 +186,10 @@ def chat_message(req: https_fn.Request) -> https_fn.Response:
     except Exception as e:
         logger.exception("Error with chatbot", e)
         return https_fn.Response(
-            response=json.dumps({"error": "Internal server error"}),
+            response=safe_json_dumps({"error": "Internal server error"}),
             status=500,
             mimetype="application/json",
             headers=headers,
         )
 
-    return https_fn.Response(response=json.dumps(results), status=200, mimetype="application/json", headers=headers)
+    return https_fn.Response(response=safe_json_dumps(results), status=200, mimetype="application/json", headers=headers)

--- a/backend/functions/schemes/schemes.py
+++ b/backend/functions/schemes/schemes.py
@@ -10,6 +10,7 @@ from firebase_functions import https_fn, options
 from loguru import logger
 from utils.cors_config import get_cors_headers, handle_cors_preflight
 from utils.auth import verify_auth_token
+from utils.json_utils import safe_json_dumps
 
 
 def create_firebase_manager() -> FirebaseManager:
@@ -67,7 +68,7 @@ def schemes(req: https_fn.Request) -> https_fn.Response:
 
     if not schemes_id:
         return https_fn.Response(
-            response=json.dumps({"error": "Invalid path parameters, please provide schemes id"}),
+            response=safe_json_dumps({"error": "Invalid path parameters, please provide schemes id"}),
             status=400,
             mimetype="application/json",
             headers=headers,
@@ -76,7 +77,7 @@ def schemes(req: https_fn.Request) -> https_fn.Response:
     # For warmup requests, return success immediately without querying Firestore
     if is_warmup:
         return https_fn.Response(
-            response=json.dumps({"message": "Warmup request successful"}),
+            response=safe_json_dumps({"message": "Warmup request successful"}),
             status=200,
             mimetype="application/json",
             headers=headers,
@@ -88,7 +89,7 @@ def schemes(req: https_fn.Request) -> https_fn.Response:
     except Exception as e:
         logger.exception("Unable to fetch scheme from firestore", e)
         return https_fn.Response(
-            response=json.dumps({"error": "Internal server error, unable to fetch scheme from firestore"}),
+            response=safe_json_dumps({"error": "Internal server error, unable to fetch scheme from firestore"}),
             status=500,
             mimetype="application/json",
             headers=headers,
@@ -96,7 +97,7 @@ def schemes(req: https_fn.Request) -> https_fn.Response:
 
     if not doc.exists:
         return https_fn.Response(
-            response=json.dumps({"error": "Scheme with provided id does not exist"}),
+            response=safe_json_dumps({"error": "Scheme with provided id does not exist"}),
             status=404,
             mimetype="application/json",
             headers=headers,
@@ -104,7 +105,7 @@ def schemes(req: https_fn.Request) -> https_fn.Response:
 
     results = {"data": doc.to_dict()}
     return https_fn.Response(
-        response=json.dumps(results),
+        response=safe_json_dumps(results),
         status=200,
         mimetype="application/json",
         headers=headers,

--- a/backend/functions/schemes/search.py
+++ b/backend/functions/schemes/search.py
@@ -11,6 +11,7 @@ from loguru import logger
 from ml_logic import PaginatedSearchParams, SearchModel
 from utils.auth import verify_auth_token
 from utils.cors_config import get_cors_headers, handle_cors_preflight
+from utils.json_utils import safe_json_dumps
 
 
 def create_search_model() -> SearchModel:
@@ -42,7 +43,7 @@ def schemes_search(req: https_fn.Request) -> https_fn.Response:
     is_valid, auth_message = verify_auth_token(req)
     if not is_valid:
         return https_fn.Response(
-            response=json.dumps({"error": f"Authentication failed: {auth_message}"}),
+            response=safe_json_dumps({"error": f"Authentication failed: {auth_message}"}),
             status=401,
             mimetype="application/json",
             headers=headers,
@@ -52,7 +53,7 @@ def schemes_search(req: https_fn.Request) -> https_fn.Response:
 
     if not req.method == "POST":
         return https_fn.Response(
-            response=json.dumps({"error": "Invalid request method; only POST is supported"}),
+            response=safe_json_dumps({"error": "Invalid request method; only POST is supported"}),
             status=405,
             mimetype="application/json",
             headers=headers,
@@ -69,7 +70,7 @@ def schemes_search(req: https_fn.Request) -> https_fn.Response:
         filters = body.get("filters", None)
     except Exception:
         return https_fn.Response(
-            response=json.dumps({"error": "Invalid request body"}),
+            response=safe_json_dumps({"error": "Invalid request body"}),
             status=400,
             mimetype="application/json",
             headers=headers,
@@ -77,7 +78,7 @@ def schemes_search(req: https_fn.Request) -> https_fn.Response:
 
     if query is None:
         return https_fn.Response(
-            response=json.dumps({"error": "Parameter 'query' in body is required"}),
+            response=safe_json_dumps({"error": "Parameter 'query' in body is required"}),
             status=400,
             mimetype="application/json",
             headers=headers,
@@ -96,7 +97,7 @@ def schemes_search(req: https_fn.Request) -> https_fn.Response:
     try:
         results = search_model.predict_paginated(params)
         return https_fn.Response(
-            response=json.dumps(results),
+            response=safe_json_dumps(results),
             status=200,
             mimetype="application/json",
             headers=headers,
@@ -104,7 +105,7 @@ def schemes_search(req: https_fn.Request) -> https_fn.Response:
     except Exception as e:
         logger.exception("Error searching schemes", e)
         return https_fn.Response(
-            response=json.dumps({"error": "Internal server error searching schemes"}),
+            response=safe_json_dumps({"error": "Internal server error searching schemes"}),
             status=500,
             mimetype="application/json",
             headers=headers,

--- a/backend/functions/schemes/search_queries.py
+++ b/backend/functions/schemes/search_queries.py
@@ -10,6 +10,7 @@ from firebase_functions import https_fn, options
 from loguru import logger
 from utils.cors_config import get_cors_headers, handle_cors_preflight
 from utils.auth import verify_auth_token
+from utils.json_utils import safe_json_dumps
 
 
 def create_firebase_manager() -> FirebaseManager:
@@ -103,4 +104,4 @@ def retrieve_search_queries(req: https_fn.Request) -> https_fn.Response:
         )
 
     results = {"data": doc.to_dict()}
-    return https_fn.Response(response=json.dumps(results), status=200, mimetype="application/json", headers=headers)
+    return https_fn.Response(response=safe_json_dumps(results), status=200, mimetype="application/json", headers=headers)


### PR DESCRIPTION



          
# Use safe_json_dumps from utils.json_utils to ensure consistent and safe JSON serialization across all response handlers

**Problem**

JSON serialization errors when handling Firestore Timestamp objects: `Object of type Timestamp is not JSON serializable` at line 99 in `/app/functions/schemes/search.py` during `json.dumps(results)` calls.

**Link to Issue:**

N/A - Identified during local development.

**Changes**

1. Created `FirestoreJSONEncoder` in `/backend/functions/utils/json_utils.py` to handle Firestore Timestamps, DatetimeWithNanoseconds, and datetime objects by converting them to ISO format strings
2. Added `safe_json_dumps()` utility function using the custom encoder
3. Replaced `json.dumps()` with `safe_json_dumps()` across all endpoints:
   - `schemes/search.py` (4 locations)
   - `schemes/schemes.py` (5 locations) 
   - `schemes/search_queries.py` (1 location)
   - `chat/chat.py` (3 locations)

**Why**

Firestore automatically adds timestamp fields that aren't JSON serializable by default. The custom encoder ensures consistent handling and production safety regardless of schema differences between environments.

**Testing**

- Verified custom encoder handles Firestore Timestamp objects correctly
- Confirmed all `json.dumps()` calls in response handlers updated
- Validated missing timestamp fields don't cause serialization errors
        