### PR TITLE
Fix address not showing in scheme page

### DIFF
--- a/frontend/src/app/schemes/[schemeId]/page.tsx
+++ b/frontend/src/app/schemes/[schemeId]/page.tsx
@@ -110,10 +110,11 @@ const mapToFullScheme = (rawData: FullSchemeData): Scheme => {
     }
   } else {
     // no physical branch. Group contact details together
-    if (rawData.phone || rawData.email) {
+    if (rawData.phone || rawData.email || rawData.address) {
       contacts.push({
         phones: rawData.phone && rawData.phone,
         emails: rawData.email && rawData.email,
+        address: rawData.address && rawData.address[0],
       });
     }
   }

--- a/frontend/src/components/schemes/scheme-card.tsx
+++ b/frontend/src/components/schemes/scheme-card.tsx
@@ -23,7 +23,8 @@ function SchemeCard({scheme}: SchemeCardProps) {
             width={60}
             radius="sm"
             classNames={{
-              wrapper: 'shrink-0'
+              wrapper: 'shrink-0',
+              img: 'object-contain'
             }}
           />
           <div className="flex flex-col">

--- a/frontend/src/components/schemes/scheme-contact-card.tsx
+++ b/frontend/src/components/schemes/scheme-contact-card.tsx
@@ -9,6 +9,10 @@ interface SchemeContactCardProps {
 }
 
 export default function SchemeContactCard({contact}: SchemeContactCardProps) {
+  if (!contact.address && !contact.phones?.length && !contact.emails?.length) {
+    return null;
+  }
+
   return (
     <Card
       className="p-4 flex flex-col gap-2"


### PR DESCRIPTION
## Summary
- Fix address field not displaying on scheme detail pages for schemes without a `planning_area`
- Hide empty contact cards when a scheme has no phone, email, or address
- Fix warped logos in search results by adding `object-contain`

## Changes
- **`app/schemes/[schemeId]/page.tsx`**: Include `address` in the contact object when there's no planning area
- **`components/schemes/scheme-contact-card.tsx`**: Return null when contact has no address, phones, or emails
- **`components/schemes/scheme-card.tsx`**: Add `object-contain` to logo image to prevent aspect ratio distortion

## Test plan
- [x] Visit a scheme with address but no planning_area (e.g. `/schemes/t2MDkbl1jjskeX5IKD75`) — address should show
- [x] Visit a scheme with no contact info (e.g. `/schemes/fw9CubwfGkAcgqB5sVpB`) — no empty white contact card
- [x] Search results should show logos without distortion