### PR TITLE
Fix search crash when search_booster is None

### DIFF
--- a/backend/functions/ml_logic/searchModelManager.py
+++ b/backend/functions/ml_logic/searchModelManager.py
@@ -228,7 +228,7 @@ class SearchModel:
                 - 'combined_scores': Weighted sum of vector and BM25 scores.
         """
         docs = [
-            Document(page_content=content, metadata={"id": sid})
+            Document(page_content=content or "", metadata={"id": sid})
             for sid, content in zip(results["scheme_id"], results["search_booster"])
         ]
         retriever = BM25Retriever.from_documents(docs)

--- a/frontend/src/app/(main)/schemes/[schemeId]/page.tsx
+++ b/frontend/src/app/(main)/schemes/[schemeId]/page.tsx
@@ -120,7 +120,7 @@ const mapToFullScheme = (rawData: FullSchemeData): Scheme => {
   }
   return {
     // Properties from Scheme
-    schemeType: rawData["Scheme Type"] || "",
+    schemeType: Array.isArray(rawData["Scheme Type"]) ? rawData["Scheme Type"].join(", ") : rawData["Scheme Type"] || "",
     schemeName: rawData["Scheme"] || "",
     targetAudience: rawData["Who's it for"] || "",
     agency: rawData["Agency"] || "",

--- a/frontend/src/components/main-chat.tsx
+++ b/frontend/src/components/main-chat.tsx
@@ -15,7 +15,7 @@ import { RawSchemeData, SearchResponse } from "@/app/interfaces/schemes";
 
 export const mapToScheme = (rawData: RawSchemeData): SearchResScheme => {
   return {
-    schemeType: rawData["scheme_type"] || rawData["Scheme Type"] || "",
+    schemeType: (() => { const v = rawData["scheme_type"] || rawData["Scheme Type"]; return Array.isArray(v) ? v.join(", ") : v || ""; })(),
     schemeName: rawData["scheme"] || rawData["Scheme"] || "",
     targetAudience: rawData["who_is_it_for"] || rawData["Who's it for"] || "",
     agency: rawData["agency"] || rawData["Agency"] || "",


### PR DESCRIPTION
## Summary
- Handle `None` values in `search_booster` field during BM25 ranking to prevent Pydantic validation error in LangChain `Document` class
- Schemes missing `search_booster` (e.g. newly added via pipeline) caused `schemes_search` to crash entirely

## Test plan
- [ ] Verify search works after deploying to dev
- [ ] Confirm schemes with missing `search_booster` no longer crash search