### PR TITLE
Fix deploy error and targetAudience/benefits crash

### DIFF
--- a/frontend/firebase.json
+++ b/frontend/firebase.json
@@ -19,10 +19,6 @@
         {
           "source": "/_next/**",
           "destination": "/_next/**"
-        },
-        {
-          "source": "**",
-          "function": "index.html"
         }
       ],
       "headers": [
@@ -56,10 +52,6 @@
         {
           "source": "/_next/**",
           "destination": "/_next/**"
-        },
-        {
-          "source": "**",
-          "function": "index.html"
         }
       ],
       "headers": [

--- a/frontend/src/app/(main)/schemes/[schemeId]/page.tsx
+++ b/frontend/src/app/(main)/schemes/[schemeId]/page.tsx
@@ -122,11 +122,11 @@ const mapToFullScheme = (rawData: FullSchemeData): Scheme => {
     // Properties from Scheme
     schemeType: Array.isArray(rawData["Scheme Type"]) ? rawData["Scheme Type"].join(", ") : rawData["Scheme Type"] || "",
     schemeName: rawData["Scheme"] || "",
-    targetAudience: rawData["Who's it for"] || "",
+    targetAudience: Array.isArray(rawData["Who's it for"]) ? rawData["Who's it for"].join(", ") : rawData["Who's it for"] || "",
     agency: rawData["Agency"] || "",
     description: rawData["Description"] || "",
     scrapedText: rawData["scraped_text"] || "",
-    benefits: rawData["What it gives"] || "",
+    benefits: Array.isArray(rawData["What it gives"]) ? rawData["What it gives"].join(", ") : rawData["What it gives"] || "",
     link: rawData["Link"] || "",
     image: rawData["Image"] || "",
     searchBooster: rawData["search_booster(WL)"] || "",


### PR DESCRIPTION
## Summary
- Remove invalid `index.html` function rewrite from `firebase.json` (both staging and prod) that caused `Failed to replace Run service` error during Firebase Hosting deploy
- Handle array values for `targetAudience` and `benefits` fields in scheme detail page to prevent `.split() is not a function` crash (same pattern as existing `schemeType` fix)

## Test plan
- [ ] Verify staging deploy completes without `Failed to replace Run service` error
- [ ] Visit a scheme detail page and confirm no `s.targetAudience.split is not a function` console error
- [ ] Confirm scheme detail page renders "Who is it for" and "What it gives" sections correctly