### PR TITLE
Release: bug fixes for search and scheme detail page

### DIFF
--- a/backend/functions/ml_logic/searchModelManager.py
+++ b/backend/functions/ml_logic/searchModelManager.py
@@ -228,7 +228,7 @@ class SearchModel:
                 - 'combined_scores': Weighted sum of vector and BM25 scores.
         """
         docs = [
-            Document(page_content=content, metadata={"id": sid})
+            Document(page_content=content or "", metadata={"id": sid})
             for sid, content in zip(results["scheme_id"], results["search_booster"])
         ]
         retriever = BM25Retriever.from_documents(docs)

--- a/frontend/firebase.json
+++ b/frontend/firebase.json
@@ -19,10 +19,6 @@
         {
           "source": "/_next/**",
           "destination": "/_next/**"
-        },
-        {
-          "source": "**",
-          "function": "index.html"
         }
       ],
       "headers": [
@@ -56,10 +52,6 @@
         {
           "source": "/_next/**",
           "destination": "/_next/**"
-        },
-        {
-          "source": "**",
-          "function": "index.html"
         }
       ],
       "headers": [

--- a/frontend/src/app/(main)/schemes/[schemeId]/page.tsx
+++ b/frontend/src/app/(main)/schemes/[schemeId]/page.tsx
@@ -122,11 +122,11 @@ const mapToFullScheme = (rawData: FullSchemeData): Scheme => {
     // Properties from Scheme
     schemeType: Array.isArray(rawData["Scheme Type"]) ? rawData["Scheme Type"].join(", ") : rawData["Scheme Type"] || "",
     schemeName: rawData["Scheme"] || "",
-    targetAudience: rawData["Who's it for"] || "",
+    targetAudience: Array.isArray(rawData["Who's it for"]) ? rawData["Who's it for"].join(", ") : rawData["Who's it for"] || "",
     agency: rawData["Agency"] || "",
     description: rawData["Description"] || "",
     scrapedText: rawData["scraped_text"] || "",
-    benefits: rawData["What it gives"] || "",
+    benefits: Array.isArray(rawData["What it gives"]) ? rawData["What it gives"].join(", ") : rawData["What it gives"] || "",
     link: rawData["Link"] || "",
     image: rawData["Image"] || "",
     searchBooster: rawData["search_booster(WL)"] || "",

--- a/frontend/src/app/(main)/schemes/[schemeId]/page.tsx
+++ b/frontend/src/app/(main)/schemes/[schemeId]/page.tsx
@@ -120,7 +120,7 @@ const mapToFullScheme = (rawData: FullSchemeData): Scheme => {
   }
   return {
     // Properties from Scheme
-    schemeType: rawData["Scheme Type"] || "",
+    schemeType: Array.isArray(rawData["Scheme Type"]) ? rawData["Scheme Type"].join(", ") : rawData["Scheme Type"] || "",
     schemeName: rawData["Scheme"] || "",
     targetAudience: rawData["Who's it for"] || "",
     agency: rawData["Agency"] || "",

--- a/frontend/src/components/main-chat.tsx
+++ b/frontend/src/components/main-chat.tsx
@@ -15,7 +15,7 @@ import { RawSchemeData, SearchResponse } from "@/app/interfaces/schemes";
 
 export const mapToScheme = (rawData: RawSchemeData): SearchResScheme => {
   return {
-    schemeType: rawData["scheme_type"] || rawData["Scheme Type"] || "",
+    schemeType: (() => { const v = rawData["scheme_type"] || rawData["Scheme Type"]; return Array.isArray(v) ? v.join(", ") : v || ""; })(),
     schemeName: rawData["scheme"] || rawData["Scheme"] || "",
     targetAudience: rawData["who_is_it_for"] || rawData["Who's it for"] || "",
     agency: rawData["agency"] || rawData["Agency"] || "",


### PR DESCRIPTION
## Summary
- Fix search crash when `search_booster` is `None` in backend
- Fix `schemeType` crash when Firestore returns array instead of string
- Fix `targetAudience` and `benefits` crash on `.split()` when value is array
- Remove invalid `index.html` function rewrite from `firebase.json` that caused deploy failure

## Commits
- `38bb7f4` Fix search crash when search_booster is None
- `3292118` Fix schemeType crash when value is array
- `ba6bb3f` Fix targetAudience/benefits crash and remove invalid index.html rewrite

## Test plan
- [x] Staging deploy succeeds without `Failed to replace Run service` error
- [ ] Search works without backend crash
- [ ] Scheme detail pages render correctly for all field types (string and array)