### PR TITLE
feat(new_scheme): support update-in-place for dead-link replacement

### DIFF
--- a/backend/functions/new_scheme/approval_handler.py
+++ b/backend/functions/new_scheme/approval_handler.py
@@ -21,6 +21,8 @@ from slack_sdk.web import WebClient
 from new_scheme.new_scheme_blocks import (
     build_new_scheme_approved_message,
     build_new_scheme_rejected_message,
+    build_scheme_update_approved_message,
+    build_scheme_update_rejected_message,
 )
 
 
@@ -81,34 +83,98 @@ def handle_new_scheme_approval(
         except Exception as e:
             logger.warning(f"Could not get reviewer email from Slack: {e}")
 
-        # Create new document in schemes collection
-        schemes_ref = db.collection("schemes").document()
-        scheme_data = {
-            **approved_data,
-            "approved_by": reviewer_email or reviewer_id,
-            "approved_at": SERVER_TIMESTAMP,
-            "source_entry_id": entry_doc_id,
-            "created_at": SERVER_TIMESTAMP,
-            "status": "active",
-            "scraped_text": original_data.get("scraped_text", ""),
-            "last_llm_processed_update": SERVER_TIMESTAMP,
-            "last_scraped_update": SERVER_TIMESTAMP,
-        }
+        # Read entry to decide new-vs-update branch
+        entry_snap = db.collection("schemeEntries").document(entry_doc_id).get()
+        entry_data = entry_snap.to_dict() if entry_snap.exists else {}
+        type_of_request = (entry_data.get("typeOfRequest") or "").lower()
+        target_scheme_id = entry_data.get("targetSchemeId")
 
-        # Rename some fields to match schemes collection schema
-        if "scheme_name" in scheme_data:
-            scheme_data["scheme"] = scheme_data.pop("scheme_name")
-        if "scheme_url" in scheme_data:
-            scheme_data["link"] = scheme_data.pop("scheme_url")
-        if "llm_description" in scheme_data:
-            scheme_data["description"] = scheme_data.get("llm_description", "")
-        if "image_url" in scheme_data:
-            scheme_data["image"] = scheme_data.pop("image_url")
+        is_update = type_of_request == "update" and bool(target_scheme_id)
 
-        schemes_ref.set(scheme_data)
-        new_scheme_id = schemes_ref.id
+        if is_update:
+            # UPDATE-in-place: PATCH the existing schemes/<target_scheme_id>
+            target_ref = db.collection("schemes").document(target_scheme_id)
 
-        logger.info(f"Created new scheme document: {new_scheme_id}")
+            # Warn if target is not currently inactive — update-in-place is
+            # expected to run against dead-link schemes (status=inactive).
+            try:
+                target_snap = target_ref.get()
+                current_status = (
+                    (target_snap.to_dict() or {}).get("status")
+                    if target_snap.exists
+                    else None
+                )
+                if current_status and current_status != "inactive":
+                    logger.warning(
+                        f"Approving update for scheme {target_scheme_id} "
+                        f"whose current status is {current_status!r} "
+                        f"(expected 'inactive'); entry={entry_doc_id}"
+                    )
+            except Exception as status_err:
+                logger.warning(
+                    f"Could not read target status for {target_scheme_id}: {status_err}"
+                )
+
+            patch = {
+                "link": approved_data.get("scheme_url"),
+                "scheme": approved_data.get("scheme_name"),
+                "description": approved_data.get("llm_description", ""),
+                "scraped_text": original_data.get("scraped_text", ""),
+                "who_is_it_for": approved_data.get("who_is_it_for", []),
+                "what_it_gives": approved_data.get("what_it_gives", []),
+                "scheme_type": approved_data.get("scheme_type", []),
+                "summary": approved_data.get("summary"),
+                "eligibility": approved_data.get("eligibility"),
+                "how_to_apply": approved_data.get("how_to_apply"),
+                "agency": approved_data.get("agency"),
+                "address": approved_data.get("address"),
+                "phone": approved_data.get("phone"),
+                "email": approved_data.get("email"),
+                "service_area": approved_data.get("service_area"),
+                "search_booster": approved_data.get("search_booster"),
+                "planning_area": approved_data.get("planning_area"),
+                "image": approved_data.get("image_url"),
+                "status": "active",
+                "link_check_status_code": 200,
+                "last_link_check": SERVER_TIMESTAMP,
+                "last_scraped_update": SERVER_TIMESTAMP,
+                "last_llm_processed_update": SERVER_TIMESTAMP,
+                "approved_by": reviewer_email or reviewer_id,
+                "approved_at": SERVER_TIMESTAMP,
+                "source_entry_id": entry_doc_id,
+            }
+            target_ref.update(patch)
+            resulting_scheme_id = target_scheme_id
+            logger.info(f"Patched existing scheme {resulting_scheme_id} via entry {entry_doc_id}")
+        else:
+            # NEW: create new document in schemes collection
+            schemes_ref = db.collection("schemes").document()
+            scheme_data = {
+                **approved_data,
+                "approved_by": reviewer_email or reviewer_id,
+                "approved_at": SERVER_TIMESTAMP,
+                "source_entry_id": entry_doc_id,
+                "created_at": SERVER_TIMESTAMP,
+                "status": "active",
+                "scraped_text": original_data.get("scraped_text", ""),
+                "last_llm_processed_update": SERVER_TIMESTAMP,
+                "last_scraped_update": SERVER_TIMESTAMP,
+            }
+
+            # Rename some fields to match schemes collection schema
+            if "scheme_name" in scheme_data:
+                scheme_data["scheme"] = scheme_data.pop("scheme_name")
+            if "scheme_url" in scheme_data:
+                scheme_data["link"] = scheme_data.pop("scheme_url")
+            if "llm_description" in scheme_data:
+                scheme_data["description"] = scheme_data.get("llm_description", "")
+            if "image_url" in scheme_data:
+                scheme_data["image"] = scheme_data.pop("image_url")
+
+            schemes_ref.set(scheme_data)
+            resulting_scheme_id = schemes_ref.id
+
+            logger.info(f"Created new scheme document: {resulting_scheme_id}")
 
         # Update schemeEntries document with approved data
         entries_ref = db.collection("schemeEntries").document(entry_doc_id)
@@ -117,7 +183,7 @@ def handle_new_scheme_approval(
                 "Status": "approved",
                 "approved_by": reviewer_email or reviewer_id,
                 "approved_at": SERVER_TIMESTAMP,
-                "approved_scheme_id": new_scheme_id,
+                "approved_scheme_id": resulting_scheme_id,
                 # Store the reviewed/edited data
                 "reviewed_data": approved_data,
                 "Scheme": approved_data.get("scheme_name"),
@@ -147,14 +213,24 @@ def handle_new_scheme_approval(
         # Update original Slack message
         if channel_id and message_ts:
             try:
-                approved_message = build_new_scheme_approved_message(
-                    doc_id=entry_doc_id,
-                    scheme_name=approved_data.get("scheme_name", "Unknown"),
-                    scheme_url=approved_data.get("scheme_url", ""),
-                    reviewer_id=reviewer_id,
-                    reviewed_at=reviewed_at,
-                    new_scheme_id=new_scheme_id,
-                )
+                if is_update:
+                    approved_message = build_scheme_update_approved_message(
+                        doc_id=entry_doc_id,
+                        scheme_name=approved_data.get("scheme_name", "Unknown"),
+                        target_scheme_id=resulting_scheme_id,
+                        new_url=approved_data.get("scheme_url", ""),
+                        reviewer_id=reviewer_id,
+                        reviewed_at=reviewed_at,
+                    )
+                else:
+                    approved_message = build_new_scheme_approved_message(
+                        doc_id=entry_doc_id,
+                        scheme_name=approved_data.get("scheme_name", "Unknown"),
+                        scheme_url=approved_data.get("scheme_url", ""),
+                        reviewer_id=reviewer_id,
+                        reviewed_at=reviewed_at,
+                        new_scheme_id=resulting_scheme_id,
+                    )
                 slack_client.chat_update(channel=channel_id, ts=message_ts, **approved_message)
             except SlackApiError as e:
                 logger.error(f"Failed to update Slack message: {e}")
@@ -162,10 +238,16 @@ def handle_new_scheme_approval(
         # Post thank you message
         if channel_id:
             try:
-                thank_text = (
-                    f"Thank you <@{reviewer_id}>! New scheme *{approved_data.get('scheme_name', 'Unknown')}* "
-                    f"has been added to the database (ID: `{new_scheme_id}`)."
-                )
+                if is_update:
+                    thank_text = (
+                        f"Thank you <@{reviewer_id}>! Scheme *{approved_data.get('scheme_name', 'Unknown')}* "
+                        f"(ID: `{resulting_scheme_id}`) updated in place."
+                    )
+                else:
+                    thank_text = (
+                        f"Thank you <@{reviewer_id}>! New scheme *{approved_data.get('scheme_name', 'Unknown')}* "
+                        f"has been added to the database (ID: `{resulting_scheme_id}`)."
+                    )
                 slack_client.chat_postMessage(channel=channel_id, text=thank_text)
             except SlackApiError:
                 pass
@@ -208,8 +290,9 @@ def handle_new_scheme_rejection(
         entry_doc = entry_ref.get()
 
         scheme_name = "Unknown"
+        entry_data: Dict[str, Any] = {}
         if entry_doc.exists:
-            entry_data = entry_doc.to_dict()
+            entry_data = entry_doc.to_dict() or {}
             scheme_name = entry_data.get("Scheme", entry_data.get("scheme_name", "Unknown"))
 
             # Update schemeEntries document
@@ -222,12 +305,28 @@ def handle_new_scheme_rejection(
                 }
             )
 
+        type_of_request = (entry_data.get("typeOfRequest") or "").lower()
+        target_scheme_id = entry_data.get("targetSchemeId")
+        is_update = type_of_request == "update" and bool(target_scheme_id)
+
         # Update original Slack message
         if channel_id and message_ts:
             try:
-                rejected_message = build_new_scheme_rejected_message(
-                    doc_id=entry_doc_id, scheme_name=scheme_name, reviewer_id=reviewer_id, reason=reason
-                )
+                if is_update:
+                    rejected_message = build_scheme_update_rejected_message(
+                        doc_id=entry_doc_id,
+                        scheme_name=scheme_name,
+                        target_scheme_id=target_scheme_id,
+                        reviewer_id=reviewer_id,
+                        reason=reason,
+                    )
+                else:
+                    rejected_message = build_new_scheme_rejected_message(
+                        doc_id=entry_doc_id,
+                        scheme_name=scheme_name,
+                        reviewer_id=reviewer_id,
+                        reason=reason,
+                    )
                 slack_client.chat_update(channel=channel_id, ts=message_ts, **rejected_message)
             except SlackApiError as e:
                 logger.error(f"Failed to update Slack message: {e}")

--- a/backend/functions/new_scheme/new_scheme_blocks.py
+++ b/backend/functions/new_scheme/new_scheme_blocks.py
@@ -22,27 +22,35 @@ def truncate_text(text: str, max_length: int = 500) -> str:
     return text[:max_length] + "..."
 
 
-def build_new_scheme_review_message(doc_id: str, processed_data: Dict[str, Any]) -> dict:
+def build_scheme_review_message(
+    doc_id: str,
+    processed_data: Dict[str, Any],
+    flavor: str = "new",
+) -> dict:
     """
     Build Slack message showing processed scheme data for human review.
 
+    The body (scraped preview, LLM fields, description) is identical for
+    both flavors; only the header, context line, top section (update adds
+    target ID + old URL), button labels, and summary text differ.
+
     Args:
         doc_id: Document ID from schemeEntries collection
-        processed_data: Result from run_scheme_processing_pipeline
+        processed_data: Result from processing pipeline
+        flavor: "new" for new-submission review, "update" for update-in-place
 
     Returns:
         Slack message payload with blocks
     """
+    is_update = flavor == "update"
+
     scheme_name = processed_data.get("scheme_name", "(No Name)")
     scheme_url = processed_data.get("scheme_url", "")
     scraped_text = processed_data.get("scraped_text", "")
-    llm_fields = processed_data.get("llm_fields", {})
+    llm_fields = processed_data.get("llm_fields", {}) or {}
     planning_area = processed_data.get("planning_area", "Not Available")
     processing_status = processed_data.get("processing_status", "unknown")
     error = processed_data.get("error")
-
-    # New scheme submissions are from anonymous users (public form)
-    # Don't display user info that may be test data
 
     # Build status indicator
     if processing_status == "completed":
@@ -51,17 +59,39 @@ def build_new_scheme_review_message(doc_id: str, processed_data: Dict[str, Any])
     elif processing_status == "scraping_failed":
         status_emoji = ":warning:"
         status_text = f"Scraping failed: {error}"
+    elif processing_status == "needs_review":
+        status_emoji = ":eyes:"
+        status_text = f"Needs manual review: {error}"
     else:
         status_emoji = ":x:"
         status_text = f"Processing failed: {error}"
 
+    # Flavor-specific header + top section + submitter + summary text
+    if is_update:
+        target_scheme_id = processed_data.get("target_scheme_id") or "?"
+        original_data = processed_data.get("original_data", {}) or {}
+        old_url = original_data.get("oldLink") or original_data.get("oldUrl") or ""
+        header_text = "Scheme Update — Replace Dead Link"
+        top_section_text = (
+            f"*{scheme_name}*  (`{target_scheme_id}`)\n"
+            f"*Old URL (dead):* {old_url or '_unknown_'}\n"
+            f"*Proposed URL:* <{scheme_url}|{scheme_url}>"
+        )
+        submitter_text = "Submitted by: automated recovery bot"
+        summary_text = f"Scheme update proposal: {scheme_name} ({target_scheme_id})"
+    else:
+        header_text = "New Scheme Submission"
+        top_section_text = f"*{scheme_name}*\n<{scheme_url}|View Original Link>"
+        submitter_text = "Submitted by: Anonymous user"
+        summary_text = f"New scheme submission: {scheme_name}"
+
     blocks = [
-        {"type": "header", "text": {"type": "plain_text", "text": "New Scheme Submission", "emoji": True}},
-        {"type": "section", "text": {"type": "mrkdwn", "text": f"*{scheme_name}*\n<{scheme_url}|View Original Link>"}},
+        {"type": "header", "text": {"type": "plain_text", "text": header_text, "emoji": True}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": top_section_text}},
         {
             "type": "context",
             "elements": [
-                {"type": "mrkdwn", "text": "Submitted by: Anonymous user"},
+                {"type": "mrkdwn", "text": submitter_text},
                 {"type": "mrkdwn", "text": f"{status_emoji} {status_text}"},
             ],
         },
@@ -140,21 +170,25 @@ def build_new_scheme_review_message(doc_id: str, processed_data: Dict[str, Any])
 
     blocks.append({"type": "divider"})
 
-    # Add action buttons
+    # Flavor-specific button labels. action_ids are identical across flavors;
+    # the approval handler branches on the entry's typeOfRequest, not the button id.
+    approve_label = "Approve Update" if is_update else "Review & Approve"
+    reject_label = "Reject Update" if is_update else "Reject"
+
     blocks.append(
         {
             "type": "actions",
             "elements": [
                 {
                     "type": "button",
-                    "text": {"type": "plain_text", "text": "Review & Approve", "emoji": True},
+                    "text": {"type": "plain_text", "text": approve_label, "emoji": True},
                     "style": "primary",
                     "action_id": "review_new_scheme",
                     "value": doc_id,
                 },
                 {
                     "type": "button",
-                    "text": {"type": "plain_text", "text": "Reject", "emoji": True},
+                    "text": {"type": "plain_text", "text": reject_label, "emoji": True},
                     "style": "danger",
                     "action_id": "reject_new_scheme",
                     "value": doc_id,
@@ -164,11 +198,16 @@ def build_new_scheme_review_message(doc_id: str, processed_data: Dict[str, Any])
     )
 
     return {
-        "text": f"New scheme submission: {scheme_name}",
+        "text": summary_text,
         "blocks": blocks,
         "unfurl_links": False,
         "unfurl_media": False,
     }
+
+
+def build_new_scheme_review_message(doc_id: str, processed_data: Dict[str, Any]) -> dict:
+    """Backward-compatible wrapper — flavor='new'."""
+    return build_scheme_review_message(doc_id, processed_data, flavor="new")
 
 
 def build_new_scheme_review_modal(metadata: str, processed_data: Dict[str, Any]) -> dict:
@@ -465,34 +504,33 @@ def build_new_scheme_review_modal(metadata: str, processed_data: Dict[str, Any])
 
 
 def build_new_scheme_approved_message(
-    doc_id: str, scheme_name: str, scheme_url: str, reviewer_id: str, reviewed_at: str, new_scheme_id: str
+    doc_id: str,
+    scheme_name: str,
+    scheme_url: str,
+    reviewer_id: str,
+    reviewed_at: str,
+    new_scheme_id: str,
+    *,
+    flavor: str = "new",
 ) -> dict:
-    """
-    Build message confirming scheme was approved and added.
-
-    Args:
-        doc_id: Original schemeEntries document ID
-        scheme_name: Approved scheme name
-        scheme_url: Scheme URL
-        reviewer_id: Slack user ID of reviewer
-        reviewed_at: ISO timestamp of approval
-        new_scheme_id: New document ID in schemes collection
-
-    Returns:
-        Slack message payload
-    """
+    """Build message confirming scheme was approved. flavor="update" for update-in-place."""
     reviewed_by = f"<@{reviewer_id}>" if reviewer_id else "a reviewer"
-
+    if flavor == "update":
+        summary = f"Scheme update approved: {scheme_name}"
+        headline = (
+            f":white_check_mark: *UPDATE APPROVED* — *{scheme_name}* "
+            f"(`{new_scheme_id}`)\nNew URL: <{scheme_url}|{scheme_url}>"
+        )
+    else:
+        summary = f"New scheme '{scheme_name}' has been approved and added."
+        headline = (
+            f":white_check_mark: *New scheme approved and added!*\n\n"
+            f"*{scheme_name}*\n<{scheme_url}|View Scheme>"
+        )
     return {
-        "text": f"New scheme '{scheme_name}' has been approved and added.",
+        "text": summary,
         "blocks": [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f":white_check_mark: *New scheme approved and added!*\n\n*{scheme_name}*\n<{scheme_url}|View Scheme>",
-                },
-            },
+            {"type": "section", "text": {"type": "mrkdwn", "text": headline}},
             {
                 "type": "context",
                 "elements": [
@@ -507,33 +545,30 @@ def build_new_scheme_approved_message(
 
 
 def build_new_scheme_rejected_message(
-    doc_id: str, scheme_name: str, reviewer_id: str, reason: Optional[str] = None
+    doc_id: str,
+    scheme_name: str,
+    reviewer_id: str,
+    reason: Optional[str] = None,
+    *,
+    flavor: str = "new",
+    target_scheme_id: Optional[str] = None,
 ) -> dict:
-    """
-    Build message confirming scheme was rejected.
-
-    Args:
-        doc_id: schemeEntries document ID
-        scheme_name: Rejected scheme name
-        reviewer_id: Slack user ID of reviewer
-        reason: Optional rejection reason
-
-    Returns:
-        Slack message payload
-    """
+    """Build message confirming scheme was rejected. flavor="update" for update-in-place."""
     reviewed_by = f"<@{reviewer_id}>" if reviewer_id else "a reviewer"
     reason_text = f"\nReason: {reason}" if reason else ""
-
+    if flavor == "update":
+        summary = f"Scheme update rejected: {scheme_name}"
+        headline = (
+            f":x: *UPDATE REJECTED* — *{scheme_name}* "
+            f"(`{target_scheme_id}`){reason_text}"
+        )
+    else:
+        summary = f"Scheme submission '{scheme_name}' was rejected."
+        headline = f":x: *Scheme submission rejected*\n\n*{scheme_name}*{reason_text}"
     return {
-        "text": f"Scheme submission '{scheme_name}' was rejected.",
+        "text": summary,
         "blocks": [
-            {
-                "type": "section",
-                "text": {
-                    "type": "mrkdwn",
-                    "text": f":x: *Scheme submission rejected*\n\n*{scheme_name}*{reason_text}",
-                },
-            },
+            {"type": "section", "text": {"type": "mrkdwn", "text": headline}},
             {
                 "type": "context",
                 "elements": [
@@ -600,3 +635,46 @@ def build_new_scheme_duplicate_message(
             },
         ],
     }
+
+
+def build_scheme_update_review_message(doc_id: str, processed_data: Dict[str, Any]) -> dict:
+    """Backward-compatible wrapper — flavor='update'."""
+    return build_scheme_review_message(doc_id, processed_data, flavor="update")
+
+
+def build_scheme_update_approved_message(
+    doc_id: str,
+    scheme_name: str,
+    target_scheme_id: str,
+    new_url: str,
+    reviewer_id: str,
+    reviewed_at: str,
+) -> dict:
+    """Thin wrapper — flavor='update' for approved builder."""
+    return build_new_scheme_approved_message(
+        doc_id=doc_id,
+        scheme_name=scheme_name,
+        scheme_url=new_url,
+        reviewer_id=reviewer_id,
+        reviewed_at=reviewed_at,
+        new_scheme_id=target_scheme_id,
+        flavor="update",
+    )
+
+
+def build_scheme_update_rejected_message(
+    doc_id: str,
+    scheme_name: str,
+    target_scheme_id: str,
+    reviewer_id: str,
+    reason: Optional[str] = None,
+) -> dict:
+    """Thin wrapper — flavor='update' for rejected builder."""
+    return build_new_scheme_rejected_message(
+        doc_id=doc_id,
+        scheme_name=scheme_name,
+        reviewer_id=reviewer_id,
+        reason=reason,
+        flavor="update",
+        target_scheme_id=target_scheme_id,
+    )

--- a/backend/functions/new_scheme/trigger_new_scheme_pipeline.py
+++ b/backend/functions/new_scheme/trigger_new_scheme_pipeline.py
@@ -97,11 +97,13 @@ def process_new_scheme_entry(doc_id: str, data: dict) -> None:
         logger.info(f"Skipping warmup/test entry: {doc_id}")
         return
 
-    # Only process new scheme submissions (not edit requests)
-    type_of_request = data.get("typeOfRequest", "").lower()
-    if type_of_request != "new":
-        logger.info(f"Skipping non-new entry (type={type_of_request}): {doc_id}")
+    # Only process new scheme submissions and update-in-place requests
+    type_of_request = (data.get("typeOfRequest") or "").lower()
+    if type_of_request not in ("new", "update"):
+        logger.info(f"Skipping non-new/update entry (type={type_of_request}): {doc_id}")
         return
+
+    target_scheme_id = data.get("targetSchemeId") if type_of_request == "update" else None
 
     # Check if already processed (prevent duplicate processing)
     if data.get("pipeline_status") == "processed":
@@ -110,7 +112,7 @@ def process_new_scheme_entry(doc_id: str, data: dict) -> None:
 
     # Check for duplicate URL (keep this in Firebase Functions for speed)
     link = data.get("Link", "")
-    duplicate = check_duplicate_scheme(link)
+    duplicate = check_duplicate_scheme(link, exclude_doc_id=target_scheme_id)
     if duplicate:
         logger.warning(f"Duplicate URL detected for {doc_id}: {duplicate}")
 
@@ -154,6 +156,8 @@ def process_new_scheme_entry(doc_id: str, data: dict) -> None:
                 "scheme_name": data.get("Scheme", "Unknown"),
                 "scheme_url": data.get("Link", ""),
                 "original_data": serialized_data,
+                "type_of_request": type_of_request,
+                "target_scheme_id": target_scheme_id,
             },
             headers=headers,
             timeout=300,  # 5 minute timeout

--- a/backend/functions/new_scheme/url_utils.py
+++ b/backend/functions/new_scheme/url_utils.py
@@ -92,7 +92,9 @@ def extract_domain(url: str) -> str:
     return hostname
 
 
-def check_duplicate_scheme(url: str) -> Optional[Dict[str, Any]]:
+def check_duplicate_scheme(
+    url: str, exclude_doc_id: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
     """
     Check if a scheme with the same URL already exists.
 
@@ -105,6 +107,9 @@ def check_duplicate_scheme(url: str) -> Optional[Dict[str, Any]]:
 
     Args:
         url: The URL to check
+        exclude_doc_id: when set, matches on this `schemes/` document ID
+            are ignored. Used by the update-in-place flow so a scheme's
+            own URL (unchanged) doesn't self-flag as a duplicate.
 
     Returns:
         Dict with existing scheme info if duplicate found, None otherwise
@@ -122,6 +127,8 @@ def check_duplicate_scheme(url: str) -> Optional[Dict[str, Any]]:
     docs = schemes_ref.stream()
 
     for doc in docs:
+        if exclude_doc_id and doc.id == exclude_doc_id:
+            continue
         data = doc.to_dict()
         existing_link = data.get("link", "")
         existing_normalized = normalize_url(existing_link)

--- a/backend/functions/update_scheme/update_scheme.py
+++ b/backend/functions/update_scheme/update_scheme.py
@@ -79,6 +79,8 @@ def update_scheme(req: https_fn.Request) -> https_fn.Response:
         userName = request_json.get("userName")
         userEmail = request_json.get("userEmail")
         typeOfRequest = request_json.get("typeOfRequest")
+        targetSchemeId = request_json.get("targetSchemeId")
+        oldLink = request_json.get("oldLink")
         is_warmup = request_json.get("is_warmup", False)
         timestamp = datetime.now(timezone.utc)
 
@@ -91,6 +93,37 @@ def update_scheme(req: https_fn.Request) -> https_fn.Response:
                 headers=headers,
             )
 
+        type_lower = (typeOfRequest or "").lower()
+
+        if type_lower == "update":
+            if not targetSchemeId or not isinstance(targetSchemeId, str):
+                return https_fn.Response(
+                    response=json.dumps({
+                        "success": False,
+                        "message": "targetSchemeId (string) is required when typeOfRequest is 'update'",
+                    }),
+                    status=400,
+                    mimetype="application/json",
+                    headers=headers,
+                )
+
+            target_snap = (
+                firebase_manager.firestore_client
+                .collection("schemes")
+                .document(targetSchemeId)
+                .get()
+            )
+            if not target_snap.exists:
+                return https_fn.Response(
+                    response=json.dumps({
+                        "success": False,
+                        "message": f"Target scheme '{targetSchemeId}' not found in schemes/",
+                    }),
+                    status=400,
+                    mimetype="application/json",
+                    headers=headers,
+                )
+
         # Prepare the data for Firestore
         update_scheme_data = {
             "Changes": changes,
@@ -99,6 +132,8 @@ def update_scheme(req: https_fn.Request) -> https_fn.Response:
             "Scheme": scheme,
             "Status": status,
             "entryId": entryId,
+            "targetSchemeId": targetSchemeId,
+            "oldLink": oldLink,
             "timestamp": timestamp,
             "userName": userName,
             "userEmail": userEmail,
@@ -112,7 +147,7 @@ def update_scheme(req: https_fn.Request) -> https_fn.Response:
 
         # In local dev mode (without Firestore emulator), triggers don't fire
         # So we call the pipeline in a background thread for new scheme submissions
-        if is_local_dev() and typeOfRequest and typeOfRequest.lower() == "new":
+        if is_local_dev() and type_lower in ("new", "update"):
             logger.info(f"Local dev mode: calling pipeline in background for {doc_id}")
 
             def run_pipeline():

--- a/backend/scheme-processor/app/clients/slack_blocks.py
+++ b/backend/scheme-processor/app/clients/slack_blocks.py
@@ -17,26 +17,36 @@ def truncate_text(text: str, max_length: int = 500) -> str:
     return text[:max_length] + "..."
 
 
-def build_new_scheme_review_message(doc_id: str, processed_data: Dict[str, Any]) -> dict:
+def build_scheme_review_message(
+    doc_id: str,
+    processed_data: Dict[str, Any],
+    flavor: str = "new",
+) -> dict:
     """
     Build Slack message showing processed scheme data for human review.
+
+    The body (scraped preview, LLM fields, description) is identical for
+    both flavors; only the header, context line, top section (update adds
+    target ID + old URL), button labels, and summary text differ.
 
     Args:
         doc_id: Document ID from schemeEntries collection
         processed_data: Result from processing pipeline
+        flavor: "new" for new-submission review, "update" for update-in-place
 
     Returns:
         Slack message payload with blocks
     """
+    is_update = flavor == "update"
+
     scheme_name = processed_data.get("scheme_name", "(No Name)")
     scheme_url = processed_data.get("scheme_url", "")
     scraped_text = processed_data.get("scraped_text", "")
-    llm_fields = processed_data.get("llm_fields", {})
+    llm_fields = processed_data.get("llm_fields", {}) or {}
     planning_area = processed_data.get("planning_area", "Not Available")
     processing_status = processed_data.get("processing_status", "unknown")
     error = processed_data.get("error")
 
-    # Build status indicator
     if processing_status == "completed":
         status_emoji = ":white_check_mark:"
         status_text = "Pipeline completed successfully"
@@ -50,20 +60,37 @@ def build_new_scheme_review_message(doc_id: str, processed_data: Dict[str, Any])
         status_emoji = ":x:"
         status_text = f"Processing failed: {error}"
 
+    if is_update:
+        target_scheme_id = processed_data.get("target_scheme_id") or "?"
+        original_data = processed_data.get("original_data", {}) or {}
+        old_url = original_data.get("oldLink") or original_data.get("oldUrl") or ""
+        header_text = "Scheme Update — Replace Dead Link"
+        top_section_text = (
+            f"*{scheme_name}*  (`{target_scheme_id}`)\n"
+            f"*Old URL (dead):* {old_url or '_unknown_'}\n"
+            f"*Proposed URL:* <{scheme_url}|{scheme_url}>"
+        )
+        submitter_text = "Submitted by: automated recovery bot"
+        summary_text = f"Scheme update proposal: {scheme_name} ({target_scheme_id})"
+    else:
+        header_text = "New Scheme Submission"
+        top_section_text = f"*{scheme_name}*\n<{scheme_url}|View Original Link>"
+        submitter_text = "Submitted by: Anonymous user"
+        summary_text = f"New scheme submission: {scheme_name}"
+
     blocks = [
-        {"type": "header", "text": {"type": "plain_text", "text": "New Scheme Submission", "emoji": True}},
-        {"type": "section", "text": {"type": "mrkdwn", "text": f"*{scheme_name}*\n<{scheme_url}|View Original Link>"}},
+        {"type": "header", "text": {"type": "plain_text", "text": header_text, "emoji": True}},
+        {"type": "section", "text": {"type": "mrkdwn", "text": top_section_text}},
         {
             "type": "context",
             "elements": [
-                {"type": "mrkdwn", "text": "Submitted by: Anonymous user"},
+                {"type": "mrkdwn", "text": submitter_text},
                 {"type": "mrkdwn", "text": f"{status_emoji} {status_text}"},
             ],
         },
         {"type": "divider"},
     ]
 
-    # Add scraped text preview if available
     if scraped_text and not scraped_text.startswith(("HTTP Error:", "Scraping Error:")):
         blocks.append(
             {
@@ -76,12 +103,10 @@ def build_new_scheme_review_message(doc_id: str, processed_data: Dict[str, Any])
         )
 
     def format_list_field(value) -> str:
-        """Format a list field for display."""
         if isinstance(value, list):
             return ", ".join(value) if value else ""
         return str(value) if value else ""
 
-    # Add LLM extracted fields
     if llm_fields:
         fields = []
 
@@ -117,11 +142,10 @@ def build_new_scheme_review_message(doc_id: str, processed_data: Dict[str, Any])
             blocks.append(
                 {
                     "type": "section",
-                    "fields": fields[:4],  # Slack allows max 10 fields, we use 4
+                    "fields": fields[:4],
                 }
             )
 
-        # Add description preview
         if llm_fields.get("llm_description"):
             blocks.append(
                 {
@@ -135,21 +159,25 @@ def build_new_scheme_review_message(doc_id: str, processed_data: Dict[str, Any])
 
     blocks.append({"type": "divider"})
 
-    # Add action buttons
+    # Flavor-specific button labels. action_ids identical across flavors;
+    # approval handler branches on entry's typeOfRequest, not button id.
+    approve_label = "Approve Update" if is_update else "Review & Approve"
+    reject_label = "Reject Update" if is_update else "Reject"
+
     blocks.append(
         {
             "type": "actions",
             "elements": [
                 {
                     "type": "button",
-                    "text": {"type": "plain_text", "text": "Review & Approve", "emoji": True},
+                    "text": {"type": "plain_text", "text": approve_label, "emoji": True},
                     "style": "primary",
                     "action_id": "review_new_scheme",
                     "value": doc_id,
                 },
                 {
                     "type": "button",
-                    "text": {"type": "plain_text", "text": "Reject", "emoji": True},
+                    "text": {"type": "plain_text", "text": reject_label, "emoji": True},
                     "style": "danger",
                     "action_id": "reject_new_scheme",
                     "value": doc_id,
@@ -159,8 +187,18 @@ def build_new_scheme_review_message(doc_id: str, processed_data: Dict[str, Any])
     )
 
     return {
-        "text": f"New scheme submission: {scheme_name}",
+        "text": summary_text,
         "blocks": blocks,
         "unfurl_links": False,
         "unfurl_media": False,
     }
+
+
+def build_new_scheme_review_message(doc_id: str, processed_data: Dict[str, Any]) -> dict:
+    """Backward-compatible wrapper — flavor='new'."""
+    return build_scheme_review_message(doc_id, processed_data, flavor="new")
+
+
+def build_scheme_update_review_message(doc_id: str, processed_data: Dict[str, Any]) -> dict:
+    """Backward-compatible wrapper — flavor='update'."""
+    return build_scheme_review_message(doc_id, processed_data, flavor="update")

--- a/backend/scheme-processor/app/clients/slack_poster.py
+++ b/backend/scheme-processor/app/clients/slack_poster.py
@@ -8,7 +8,7 @@ import os
 from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
-from app.clients.slack_blocks import build_new_scheme_review_message
+from app.clients.slack_blocks import build_scheme_review_message
 from loguru import logger
 from slack_sdk.errors import SlackApiError
 from slack_sdk.web import WebClient
@@ -51,8 +51,8 @@ def post_to_slack_for_review(doc_id: str, processed_data: Dict[str, Any], db=Non
             logger.warning("Slack not configured, skipping notification")
             return None
 
-        # Build Slack message
-        message = build_new_scheme_review_message(doc_id, processed_data)
+        flavor = (processed_data.get("type_of_request") or "new").lower()
+        message = build_scheme_review_message(doc_id, processed_data, flavor=flavor)
 
         # Post to Slack
         response = slack_client.chat_postMessage(channel=channel, **message)

--- a/backend/scheme-processor/app/main.py
+++ b/backend/scheme-processor/app/main.py
@@ -57,6 +57,8 @@ async def process(request: ProcessRequest):
             scheme_name=request.scheme_name,
             scheme_url=request.scheme_url,
             original_data=request.original_data,
+            type_of_request=request.type_of_request,
+            target_scheme_id=request.target_scheme_id,
         )
         return ProcessResponse(**result)
 

--- a/backend/scheme-processor/app/models.py
+++ b/backend/scheme-processor/app/models.py
@@ -1,6 +1,6 @@
 """Pydantic models for API request/response."""
 
-from typing import Optional
+from typing import Literal, Optional
 
 from pydantic import BaseModel
 
@@ -12,6 +12,8 @@ class ProcessRequest(BaseModel):
     scheme_name: str
     scheme_url: str
     original_data: dict = {}
+    type_of_request: Literal["new", "update"] = "new"
+    target_scheme_id: Optional[str] = None
 
 
 class ProcessResponse(BaseModel):

--- a/backend/scheme-processor/app/pipeline.py
+++ b/backend/scheme-processor/app/pipeline.py
@@ -5,7 +5,7 @@ Orchestrates scraping, LLM extraction, and Slack posting.
 """
 
 from datetime import datetime, timezone
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from app.clients.firestore import get_firestore_client, update_scheme_entry
 from app.clients.onemap import PlanningAreaService
@@ -17,7 +17,12 @@ from loguru import logger
 
 
 async def process_scheme(
-    doc_id: str, scheme_name: str, scheme_url: str, original_data: Dict[str, Any]
+    doc_id: str,
+    scheme_name: str,
+    scheme_url: str,
+    original_data: Dict[str, Any],
+    type_of_request: str = "new",
+    target_scheme_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """
     Run full processing pipeline for a scheme submission.
@@ -104,6 +109,8 @@ async def process_scheme(
             "original_data": original_data,
             "processing_status": processing_status,
             "error": error_msg,
+            "type_of_request": type_of_request,
+            "target_scheme_id": target_scheme_id,
         }
 
         # Step 5: Update Firestore

--- a/backend/tests/integration/test_approval_handler_update.py
+++ b/backend/tests/integration/test_approval_handler_update.py
@@ -1,0 +1,310 @@
+"""Integration tests for approval handler's update-in-place branch."""
+
+import json
+from typing import Optional
+
+
+def _approval_event(scheme_url: str = "https://example.com/replacement") -> dict:
+    return {
+        "user": {"id": "U123"},
+        "view": {
+            "private_metadata": json.dumps(
+                {"doc_id": "entry-1", "channel": "C1", "message_ts": "1.0"}
+            ),
+            "state": {
+                "values": {
+                    "scheme_name_block": {
+                        "scheme_name": {"value": "Existing Scheme"}
+                    },
+                    "scheme_url_block": {"scheme_url": {"value": scheme_url}},
+                    "agency_block": {"agency": {"value": "SkillsFuture SG"}},
+                    "image_url_block": {"image_url": {"value": ""}},
+                    "address_block": {"address": {"value": ""}},
+                    "phone_block": {"phone": {"value": ""}},
+                    "email_block": {"email": {"value": ""}},
+                    "planning_area_block": {"planning_area": {"value": ""}},
+                    "who_is_it_for_block": {
+                        "who_is_it_for": {"selected_options": []}
+                    },
+                    "what_it_gives_block": {
+                        "what_it_gives": {"selected_options": []}
+                    },
+                    "scheme_type_block": {
+                        "scheme_type": {"selected_options": []}
+                    },
+                    "llm_description_block": {
+                        "llm_description": {"value": "Updated description."}
+                    },
+                    "eligibility_block": {"eligibility": {"value": ""}},
+                    "how_to_apply_block": {"how_to_apply": {"value": ""}},
+                }
+            },
+        },
+    }
+
+
+def _entry_dict(
+    type_of_request: str = "update",
+    target_scheme_id: Optional[str] = "scheme-abc",
+) -> dict:
+    return {
+        "typeOfRequest": type_of_request,
+        "targetSchemeId": target_scheme_id,
+        "Scheme": "Existing Scheme",
+        "Link": "https://example.com/replacement",
+        "scraped_text": "Some new page text.",
+        "llm_fields": {"llm_description": "Updated description."},
+    }
+
+
+def _wire_db(mocker, entry_data: dict, target_status: Optional[str] = "inactive"):
+    """Return (db_mock, entry_ref, target_or_new_ref)."""
+    db = mocker.MagicMock()
+    entry_ref = mocker.MagicMock()
+    entry_snap = mocker.MagicMock()
+    entry_snap.exists = True
+    entry_snap.to_dict.return_value = entry_data
+    entry_ref.get.return_value = entry_snap
+
+    target_or_new_ref = mocker.MagicMock()
+    target_or_new_ref.id = entry_data.get("targetSchemeId") or "scheme-new"
+
+    target_snap = mocker.MagicMock()
+    target_snap.exists = target_status is not None
+    target_snap.to_dict.return_value = (
+        {"status": target_status} if target_status is not None else None
+    )
+    target_or_new_ref.get.return_value = target_snap
+
+    def collection(name):
+        col = mocker.MagicMock()
+        if name == "schemeEntries":
+            col.document.return_value = entry_ref
+        elif name == "schemes":
+            col.document.return_value = target_or_new_ref
+        return col
+
+    db.collection.side_effect = collection
+    mocker.patch(
+        "new_scheme.approval_handler.firestore.client", return_value=db
+    )
+    return db, entry_ref, target_or_new_ref
+
+
+def _mock_slack(mocker):
+    slack = mocker.MagicMock()
+    slack.users_info.return_value = {
+        "ok": True,
+        "user": {"profile": {"email": "rev@example.com"}},
+    }
+    return slack
+
+
+def test_update_approval_patches_target_scheme(mocker):
+    from new_scheme import approval_handler as mod
+
+    entry_data = _entry_dict()
+    db, entry_ref, target_ref = _wire_db(mocker, entry_data)
+    mocker.patch.object(
+        mod,
+        "get_processed_data_from_entry",
+        return_value={
+            "original_data": {"scraped_text": "Some new page text."},
+            "llm_fields": {},
+        },
+    )
+    slack = _mock_slack(mocker)
+
+    mod.handle_new_scheme_approval(slack, _approval_event(), "entry-1")
+
+    target_ref.update.assert_called_once()
+    patch = target_ref.update.call_args.args[0]
+    assert patch["link"] == "https://example.com/replacement"
+    assert patch["scheme"] == "Existing Scheme"
+    assert patch["status"] == "active"
+    assert patch["link_check_status_code"] == 200
+    assert "last_link_check" in patch
+    assert "last_scraped_update" in patch
+    assert "last_llm_processed_update" in patch
+    assert patch["approved_by"] == "rev@example.com"
+    assert patch["source_entry_id"] == "entry-1"
+
+    # Must not have created a new doc
+    target_ref.set.assert_not_called()
+
+
+def test_update_approval_writes_update_flavored_slack(mocker):
+    from new_scheme import approval_handler as mod
+
+    entry_data = _entry_dict()
+    _wire_db(mocker, entry_data)
+    mocker.patch.object(
+        mod,
+        "get_processed_data_from_entry",
+        return_value={"original_data": {"scraped_text": ""}, "llm_fields": {}},
+    )
+
+    update_msg_builder = mocker.patch.object(
+        mod, "build_scheme_update_approved_message", return_value={"blocks": []}
+    )
+    new_msg_builder = mocker.patch.object(
+        mod, "build_new_scheme_approved_message", return_value={"blocks": []}
+    )
+    slack = _mock_slack(mocker)
+
+    mod.handle_new_scheme_approval(slack, _approval_event(), "entry-1")
+
+    update_msg_builder.assert_called_once()
+    new_msg_builder.assert_not_called()
+    kwargs = update_msg_builder.call_args.kwargs
+    assert kwargs["target_scheme_id"] == "scheme-abc"
+    assert kwargs["new_url"] == "https://example.com/replacement"
+
+
+def test_update_approval_persists_resulting_id_on_entry(mocker):
+    from new_scheme import approval_handler as mod
+
+    entry_data = _entry_dict()
+    db, entry_ref, target_ref = _wire_db(mocker, entry_data)
+    mocker.patch.object(
+        mod,
+        "get_processed_data_from_entry",
+        return_value={"original_data": {"scraped_text": ""}, "llm_fields": {}},
+    )
+    slack = _mock_slack(mocker)
+
+    mod.handle_new_scheme_approval(slack, _approval_event(), "entry-1")
+
+    # entry_ref.update called once to write approval status
+    entry_ref.update.assert_called_once()
+    entry_patch = entry_ref.update.call_args.args[0]
+    assert entry_patch["approved_scheme_id"] == "scheme-abc"
+    assert entry_patch["Status"] == "approved"
+
+
+def test_new_approval_still_creates_doc(mocker):
+    from new_scheme import approval_handler as mod
+
+    entry_data = _entry_dict(type_of_request="new", target_scheme_id=None)
+    db, entry_ref, new_doc_ref = _wire_db(mocker, entry_data)
+    mocker.patch.object(
+        mod,
+        "get_processed_data_from_entry",
+        return_value={"original_data": {"scraped_text": ""}, "llm_fields": {}},
+    )
+    slack = _mock_slack(mocker)
+
+    mod.handle_new_scheme_approval(slack, _approval_event(), "entry-1")
+
+    new_doc_ref.set.assert_called_once()
+    new_doc_ref.update.assert_not_called()
+
+
+def test_update_rejection_uses_update_flavored_message(mocker):
+    from new_scheme import approval_handler as mod
+
+    entry_data = _entry_dict()
+    db, entry_ref, target_ref = _wire_db(mocker, entry_data)
+
+    update_reject_builder = mocker.patch.object(
+        mod, "build_scheme_update_rejected_message", return_value={"blocks": []}
+    )
+    new_reject_builder = mocker.patch.object(
+        mod, "build_new_scheme_rejected_message", return_value={"blocks": []}
+    )
+    slack = mocker.MagicMock()
+
+    mod.handle_new_scheme_rejection(
+        slack, "entry-1", "C1", "1.0", "U123", reason="bad fit"
+    )
+
+    # Target scheme doc untouched
+    target_ref.update.assert_not_called()
+    target_ref.set.assert_not_called()
+
+    # Entry marked rejected
+    entry_ref.update.assert_called_once()
+    assert entry_ref.update.call_args.args[0]["Status"] == "rejected"
+
+    update_reject_builder.assert_called_once()
+    new_reject_builder.assert_not_called()
+    kwargs = update_reject_builder.call_args.kwargs
+    assert kwargs["target_scheme_id"] == "scheme-abc"
+    assert kwargs["reason"] == "bad fit"
+
+
+def test_new_rejection_uses_new_flavored_message(mocker):
+    from new_scheme import approval_handler as mod
+
+    entry_data = _entry_dict(type_of_request="new", target_scheme_id=None)
+    _wire_db(mocker, entry_data)
+
+    update_reject_builder = mocker.patch.object(
+        mod, "build_scheme_update_rejected_message", return_value={"blocks": []}
+    )
+    new_reject_builder = mocker.patch.object(
+        mod, "build_new_scheme_rejected_message", return_value={"blocks": []}
+    )
+    slack = mocker.MagicMock()
+
+    mod.handle_new_scheme_rejection(
+        slack, "entry-1", "C1", "1.0", "U123", reason=None
+    )
+
+    new_reject_builder.assert_called_once()
+    update_reject_builder.assert_not_called()
+
+
+def test_update_approval_warns_when_target_status_active(mocker, caplog):
+    """Approving update-in-place against an active target should log a warning."""
+    import logging
+
+    from new_scheme import approval_handler as mod
+
+    entry_data = _entry_dict()
+    _wire_db(mocker, entry_data, target_status="active")
+    mocker.patch.object(
+        mod,
+        "get_processed_data_from_entry",
+        return_value={"original_data": {"scraped_text": ""}, "llm_fields": {}},
+    )
+    slack = _mock_slack(mocker)
+
+    warnings: list[str] = []
+
+    def _capture_warning(msg, *args, **kwargs):
+        warnings.append(str(msg))
+
+    mocker.patch.object(mod.logger, "warning", side_effect=_capture_warning)
+
+    with caplog.at_level(logging.WARNING):
+        mod.handle_new_scheme_approval(slack, _approval_event(), "entry-1")
+
+    assert any(
+        "scheme-abc" in w and "'active'" in w for w in warnings
+    ), f"expected active-status warning; got: {warnings}"
+
+
+def test_update_approval_no_warning_when_target_inactive(mocker):
+    """Approving update-in-place against inactive target should not warn about status."""
+    from new_scheme import approval_handler as mod
+
+    entry_data = _entry_dict()
+    _wire_db(mocker, entry_data, target_status="inactive")
+    mocker.patch.object(
+        mod,
+        "get_processed_data_from_entry",
+        return_value={"original_data": {"scraped_text": ""}, "llm_fields": {}},
+    )
+    slack = _mock_slack(mocker)
+
+    warnings: list[str] = []
+
+    def _capture_warning(msg, *args, **kwargs):
+        warnings.append(str(msg))
+
+    mocker.patch.object(mod.logger, "warning", side_effect=_capture_warning)
+
+    mod.handle_new_scheme_approval(slack, _approval_event(), "entry-1")
+
+    assert not any("current status" in w for w in warnings)

--- a/backend/tests/integration/test_trigger_new_scheme_pipeline.py
+++ b/backend/tests/integration/test_trigger_new_scheme_pipeline.py
@@ -1,0 +1,105 @@
+"""Integration tests for the new-scheme pipeline trigger (update flow)."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _stub_processor_url(monkeypatch):
+    monkeypatch.setenv("PROCESSOR_SERVICE_URL", "http://scheme-processor:8081")
+
+
+@pytest.fixture
+def update_data():
+    return {
+        "Scheme": "Example Scheme",
+        "Link": "https://example.com/foo",
+        "typeOfRequest": "update",
+        "targetSchemeId": "scheme-abc",
+    }
+
+
+def _patch_common(mocker):
+    from new_scheme import trigger_new_scheme_pipeline as mod
+
+    post_mock = mocker.patch.object(mod.requests, "post")
+    post_mock.return_value = MagicMock()
+    post_mock.return_value.json.return_value = {"success": True}
+    post_mock.return_value.raise_for_status = MagicMock()
+    mocker.patch.object(mod, "get_identity_token", return_value="tok")
+    mocker.patch.object(mod, "firestore")
+    return mod, post_mock
+
+
+def test_process_new_scheme_entry_update_forwards_target(mocker, update_data):
+    mod, post_mock = _patch_common(mocker)
+    mocker.patch.object(mod, "check_duplicate_scheme", return_value=None)
+
+    mod.process_new_scheme_entry("entry-1", update_data)
+
+    call = post_mock.call_args
+    body = call.kwargs["json"]
+    assert body["doc_id"] == "entry-1"
+    assert body["type_of_request"] == "update"
+    assert body["target_scheme_id"] == "scheme-abc"
+    assert body["scheme_url"] == "https://example.com/foo"
+
+
+def test_process_new_scheme_entry_update_excludes_target_from_dup(mocker, update_data):
+    mod, _ = _patch_common(mocker)
+    dup_mock = mocker.patch.object(mod, "check_duplicate_scheme", return_value=None)
+
+    mod.process_new_scheme_entry("entry-1", update_data)
+
+    dup_mock.assert_called_once_with("https://example.com/foo", exclude_doc_id="scheme-abc")
+
+
+def test_process_new_scheme_entry_new_keeps_old_behaviour(mocker):
+    mod, post_mock = _patch_common(mocker)
+    dup_mock = mocker.patch.object(mod, "check_duplicate_scheme", return_value=None)
+
+    mod.process_new_scheme_entry(
+        "entry-2",
+        {
+            "Scheme": "New Scheme",
+            "Link": "https://example.com/new",
+            "typeOfRequest": "new",
+        },
+    )
+
+    dup_mock.assert_called_once_with("https://example.com/new", exclude_doc_id=None)
+    body = post_mock.call_args.kwargs["json"]
+    assert body["type_of_request"] == "new"
+    assert body["target_scheme_id"] is None
+
+
+def test_process_new_scheme_entry_edit_still_skipped(mocker):
+    mod, post_mock = _patch_common(mocker)
+
+    mod.process_new_scheme_entry(
+        "entry-3",
+        {"Scheme": "X", "Link": "https://x", "typeOfRequest": "Edit"},
+    )
+
+    post_mock.assert_not_called()
+
+
+def test_process_new_scheme_entry_update_duplicate_short_circuits(mocker, update_data):
+    mod, post_mock = _patch_common(mocker)
+    mocker.patch.object(
+        mod,
+        "check_duplicate_scheme",
+        return_value={
+            "doc_id": "scheme-xyz",
+            "scheme": "Other",
+            "link": "https://example.com/foo",
+            "normalized_url": "example.com/foo",
+        },
+    )
+    mocker.patch.object(mod, "post_duplicate_to_slack")
+
+    mod.process_new_scheme_entry("entry-1", update_data)
+
+    # Short-circuit: no Cloud Run call
+    post_mock.assert_not_called()

--- a/backend/tests/integration/test_update_scheme.py
+++ b/backend/tests/integration/test_update_scheme.py
@@ -176,3 +176,120 @@ def test_update_scheme_cors_preflight(mock_request, mock_https_response, mock_au
 
     assert response.status_code == 204
     assert response.headers.get("Access-Control-Allow-Origin") == "http://localhost:3000"
+
+
+def test_update_scheme_update_type_missing_target(
+    mock_request, mock_https_response, mock_auth, mocker
+):
+    """typeOfRequest=update requires targetSchemeId."""
+    mock_manager = mocker.MagicMock()
+    mocker.patch("update_scheme.update_scheme.firebase_manager", mock_manager)
+
+    request_data = {
+        "Link": "https://example.com/replacement",
+        "Scheme": "Existing Scheme",
+        "typeOfRequest": "update",
+        "userEmail": "bot@example.com",
+        "userName": "recover-scheme-links",
+    }
+
+    response = update_scheme(mock_request(method="POST", json_data=request_data))
+    assert response.status_code == 400
+    body = json.loads(response.get_data())
+    assert body["success"] is False
+    assert "targetSchemeId" in body["message"]
+
+
+def test_update_scheme_update_type_unknown_target(
+    mock_request, mock_https_response, mock_auth, mocker
+):
+    """typeOfRequest=update with unknown targetSchemeId -> 400."""
+    mock_manager = mocker.MagicMock()
+    mock_doc = mocker.MagicMock()
+    mock_doc.exists = False
+    mock_manager.firestore_client.collection().document().get.return_value = mock_doc
+    mocker.patch("update_scheme.update_scheme.firebase_manager", mock_manager)
+
+    request_data = {
+        "Link": "https://example.com/replacement",
+        "Scheme": "Existing Scheme",
+        "typeOfRequest": "update",
+        "targetSchemeId": "nonexistent-id",
+    }
+
+    response = update_scheme(mock_request(method="POST", json_data=request_data))
+    assert response.status_code == 400
+    body = json.loads(response.get_data())
+    assert body["success"] is False
+    assert "nonexistent-id" in body["message"]
+    assert "not found" in body["message"].lower()
+
+
+def test_update_scheme_update_type_happy_path(
+    mock_request, mock_https_response, mock_auth, mocker
+):
+    """typeOfRequest=update with valid target persists targetSchemeId on entry row."""
+    mock_manager = mocker.MagicMock()
+    mock_doc_ref = mocker.MagicMock()
+    mock_doc_ref.id = "entry-42"
+    mock_target = mocker.MagicMock()
+    mock_target.exists = True
+    mock_target.to_dict.return_value = {"scheme": "Existing Scheme"}
+    mock_manager.firestore_client.collection().document().get.return_value = mock_target
+    mock_manager.firestore_client.collection().add.return_value = (
+        mocker.MagicMock(),
+        mock_doc_ref,
+    )
+    mocker.patch("update_scheme.update_scheme.firebase_manager", mock_manager)
+
+    request_data = {
+        "Link": "https://example.com/replacement",
+        "Scheme": "Existing Scheme",
+        "typeOfRequest": "update",
+        "targetSchemeId": "scheme-abc",
+        "oldLink": "https://old-dead-url.example/",
+        "userEmail": "bot@example.com",
+        "userName": "recover-scheme-links",
+    }
+
+    response = update_scheme(mock_request(method="POST", json_data=request_data))
+    assert response.status_code == 200
+
+    body = json.loads(response.get_data())
+    assert body["success"] is True
+    assert body["docId"] == "entry-42"
+
+    add_calls = mock_manager.firestore_client.collection().add.call_args_list
+    persisted = next(
+        (
+            call.args[0]
+            for call in add_calls
+            if call.args and call.args[0].get("targetSchemeId") == "scheme-abc"
+        ),
+        None,
+    )
+    assert persisted is not None
+    assert persisted.get("oldLink") == "https://old-dead-url.example/"
+
+
+def test_update_scheme_update_type_non_string_target_rejected(
+    mock_request, mock_https_response, mock_auth, mocker
+):
+    """typeOfRequest=update with non-string targetSchemeId -> 400."""
+    mock_manager = mocker.MagicMock()
+    mocker.patch("update_scheme.update_scheme.firebase_manager", mock_manager)
+
+    request_data = {
+        "Link": "https://example.com/replacement",
+        "Scheme": "Existing Scheme",
+        "typeOfRequest": "update",
+        "targetSchemeId": 123,  # not a string
+    }
+
+    response = update_scheme(mock_request(method="POST", json_data=request_data))
+    assert response.status_code == 400
+    body = json.loads(response.get_data())
+    assert body["success"] is False
+    assert "targetSchemeId" in body["message"]
+    # Must not hit Firestore at all (bail before .collection("schemes"))
+    mock_manager.firestore_client.collection().document().get.assert_not_called()

--- a/backend/tests/unit/test_scheme_review_blocks.py
+++ b/backend/tests/unit/test_scheme_review_blocks.py
@@ -1,0 +1,145 @@
+"""Unit tests for the consolidated scheme review Slack block builder."""
+
+from new_scheme.new_scheme_blocks import (
+    build_new_scheme_review_message,
+    build_scheme_review_message,
+    build_scheme_update_review_message,
+)
+
+
+def _base_payload() -> dict:
+    return {
+        "scheme_name": "Test Scheme",
+        "scheme_url": "https://example.com/scheme",
+        "scraped_text": "Some scraped text content.",
+        "llm_fields": {
+            "llm_description": "A test description.",
+            "who_is_it_for": ["seniors", "families"],
+            "what_it_gives": ["cash", "vouchers"],
+            "scheme_type": ["financial"],
+        },
+        "planning_area": "Bedok",
+        "processing_status": "completed",
+        "error": None,
+    }
+
+
+def _block_types(msg: dict) -> list[str]:
+    return [b.get("type") for b in msg["blocks"]]
+
+
+def _first_section_text(msg: dict) -> str:
+    for block in msg["blocks"]:
+        if block.get("type") == "section" and block.get("text"):
+            return block["text"]["text"]
+    return ""
+
+
+def _header_text(msg: dict) -> str:
+    for block in msg["blocks"]:
+        if block.get("type") == "header":
+            return block["text"]["text"]
+    return ""
+
+
+def _action_labels(msg: dict) -> list[str]:
+    for block in msg["blocks"]:
+        if block.get("type") == "actions":
+            return [el["text"]["text"] for el in block["elements"]]
+    return []
+
+
+def test_new_and_update_share_body_block_sequence():
+    """Same scraped + LLM fields + description blocks; only header + first section + buttons differ."""
+    payload = _base_payload()
+    new_msg = build_scheme_review_message("doc-1", payload, flavor="new")
+    update_payload = {
+        **payload,
+        "target_scheme_id": "scheme-abc",
+        "original_data": {"oldLink": "https://old-dead.example/"},
+    }
+    update_msg = build_scheme_review_message("doc-1", update_payload, flavor="update")
+
+    assert _block_types(new_msg) == _block_types(update_msg)
+
+
+def test_new_header_and_buttons():
+    msg = build_scheme_review_message("doc-1", _base_payload(), flavor="new")
+    assert _header_text(msg) == "New Scheme Submission"
+    assert _action_labels(msg) == ["Review & Approve", "Reject"]
+    assert msg["text"] == "New scheme submission: Test Scheme"
+
+
+def test_update_header_and_buttons():
+    payload = {
+        **_base_payload(),
+        "target_scheme_id": "scheme-abc",
+        "original_data": {"oldLink": "https://old-dead.example/"},
+    }
+    msg = build_scheme_review_message("doc-1", payload, flavor="update")
+    assert _header_text(msg) == "Scheme Update — Replace Dead Link"
+    assert _action_labels(msg) == ["Approve Update", "Reject Update"]
+    assert "scheme-abc" in msg["text"]
+
+
+def test_update_top_section_shows_target_and_old_url():
+    payload = {
+        **_base_payload(),
+        "target_scheme_id": "scheme-abc",
+        "original_data": {"oldLink": "https://old-dead.example/"},
+    }
+    msg = build_scheme_review_message("doc-1", payload, flavor="update")
+    section = _first_section_text(msg)
+    assert "scheme-abc" in section
+    assert "https://old-dead.example/" in section
+    assert "https://example.com/scheme" in section
+
+
+def test_update_top_section_unknown_old_url_when_missing():
+    payload = {
+        **_base_payload(),
+        "target_scheme_id": "scheme-abc",
+        "original_data": {},
+    }
+    msg = build_scheme_review_message("doc-1", payload, flavor="update")
+    section = _first_section_text(msg)
+    assert "_unknown_" in section
+
+
+def test_action_ids_same_across_flavors():
+    """Approval handler dispatches on entry typeOfRequest, so action_ids must match."""
+    new_msg = build_scheme_review_message("doc-1", _base_payload(), flavor="new")
+    update_payload = {
+        **_base_payload(),
+        "target_scheme_id": "scheme-abc",
+        "original_data": {"oldLink": "x"},
+    }
+    update_msg = build_scheme_review_message("doc-1", update_payload, flavor="update")
+
+    def _ids(msg):
+        for block in msg["blocks"]:
+            if block.get("type") == "actions":
+                return [el["action_id"] for el in block["elements"]]
+        return []
+
+    assert _ids(new_msg) == _ids(update_msg) == ["review_new_scheme", "reject_new_scheme"]
+
+
+def test_legacy_wrappers_route_to_correct_flavor():
+    payload = _base_payload()
+    new_legacy = build_new_scheme_review_message("doc-1", payload)
+    new_direct = build_scheme_review_message("doc-1", payload, flavor="new")
+    assert new_legacy == new_direct
+
+    upd_payload = {**payload, "target_scheme_id": "s-1", "original_data": {"oldLink": "x"}}
+    update_legacy = build_scheme_update_review_message("doc-1", upd_payload)
+    update_direct = build_scheme_review_message("doc-1", upd_payload, flavor="update")
+    assert update_legacy == update_direct
+
+
+def test_scraping_failed_status_emoji():
+    payload = {**_base_payload(), "processing_status": "scraping_failed", "error": "404"}
+    msg = build_scheme_review_message("doc-1", payload, flavor="update")
+    elements = next(b for b in msg["blocks"] if b.get("type") == "context")["elements"]
+    status_line = next(e["text"] for e in elements if ":warning:" in e["text"])
+    assert "404" in status_line

--- a/backend/tests/unit/test_url_utils.py
+++ b/backend/tests/unit/test_url_utils.py
@@ -1,0 +1,80 @@
+"""Unit tests for new_scheme.url_utils."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from new_scheme.url_utils import check_duplicate_scheme, normalize_url
+
+
+def test_normalize_url_strips_www_and_trailing_slash():
+    assert normalize_url("https://www.example.com/foo/") == "example.com/foo"
+
+
+def test_normalize_url_strips_query_and_fragment():
+    assert normalize_url("https://Example.com/foo?ref=1#x") == "example.com/foo"
+
+
+def test_check_duplicate_scheme_finds_match(mocker):
+    doc_a = MagicMock()
+    doc_a.id = "scheme-a"
+    doc_a.to_dict.return_value = {
+        "link": "https://www.example.com/foo",
+        "scheme": "Alpha",
+    }
+
+    client = MagicMock()
+    client.collection.return_value.stream.return_value = [doc_a]
+    mocker.patch("new_scheme.url_utils.firestore.client", return_value=client)
+
+    result = check_duplicate_scheme("https://example.com/foo/")
+    assert result is not None
+    assert result["doc_id"] == "scheme-a"
+    assert result["scheme"] == "Alpha"
+
+
+def test_check_duplicate_scheme_excludes_target(mocker):
+    doc_a = MagicMock()
+    doc_a.id = "scheme-a"
+    doc_a.to_dict.return_value = {"link": "https://www.example.com/foo"}
+
+    client = MagicMock()
+    client.collection.return_value.stream.return_value = [doc_a]
+    mocker.patch("new_scheme.url_utils.firestore.client", return_value=client)
+
+    result = check_duplicate_scheme(
+        "https://example.com/foo/", exclude_doc_id="scheme-a"
+    )
+    assert result is None
+
+
+def test_check_duplicate_scheme_excludes_target_but_finds_other(mocker):
+    doc_a = MagicMock()
+    doc_a.id = "scheme-a"
+    doc_a.to_dict.return_value = {"link": "https://example.com/foo", "scheme": "A"}
+
+    doc_b = MagicMock()
+    doc_b.id = "scheme-b"
+    doc_b.to_dict.return_value = {"link": "https://example.com/foo", "scheme": "B"}
+
+    client = MagicMock()
+    client.collection.return_value.stream.return_value = [doc_a, doc_b]
+    mocker.patch("new_scheme.url_utils.firestore.client", return_value=client)
+
+    result = check_duplicate_scheme(
+        "https://example.com/foo/", exclude_doc_id="scheme-a"
+    )
+    assert result is not None
+    assert result["doc_id"] == "scheme-b"
+
+
+def test_check_duplicate_scheme_no_match(mocker):
+    doc = MagicMock()
+    doc.id = "other"
+    doc.to_dict.return_value = {"link": "https://nope.com/x"}
+
+    client = MagicMock()
+    client.collection.return_value.stream.return_value = [doc]
+    mocker.patch("new_scheme.url_utils.firestore.client", return_value=client)
+
+    assert check_duplicate_scheme("https://example.com/foo/") is None


### PR DESCRIPTION
  Entries with typeOfRequest="update" now PATCH the existing schemes/<targetSchemeId>   instead of creating a new document. Drives the automated dead-link recovery flow: a bot submits a replacement URL, reviewers see an update-flavored Slack card, and approval rewrites the target scheme in place rather than duplicating it.

  - trigger + update_scheme: accept typeOfRequest="update" with targetSchemeId/oldLink
  - pipeline + processor: thread type_of_request/target_scheme_id through to Slack
  - slack_blocks: unify new/update review cards under build_scheme_review_message
  - approval_handler: branch on typeOfRequest — patch existing vs insert new
  - check_duplicate_scheme: exclude_doc_id so a scheme's own URL isn't self-flagged
  - tests: unit + integration coverage for update flow and url exclusion

**Problem**

Provide the description of the problem. 

**Link to Issue:**

Provide the link to issue

**Changes**

Explain changes made. 

**Why**

Explain rationale for changes to help the reviewer. 

**Testing**

Indicate what testing done. Like testing local, testing on dev backend, testing on dev UI. 
