### PR TITLE
Fix scheduled link-check-and-reindex failures (list crash + Slack block cap)

### DIFF
--- a/backend/functions/batch_jobs/slack_blocks.py
+++ b/backend/functions/batch_jobs/slack_blocks.py
@@ -4,7 +4,57 @@ Slack Block Kit builders for link check & reindex batch job.
 Builds summary messages for link health check results.
 """
 
-from typing import Any, Dict, List
+from typing import Any, Callable, Dict, List
+
+
+MAX_LINKS_PER_BLOCK = 10
+SLACK_MAX_BLOCKS = 50
+
+
+def _format_dead_link(link: Dict[str, Any]) -> str:
+    doc_id = link.get("doc_id", "Unknown")
+    scheme_name = link.get("scheme_name", "Unknown")
+    link_url = link.get("link", "")
+    error = link.get("error", "Unknown error")
+    return f"• *{scheme_name}*\n  ID: `{doc_id}`\n  Link: {link_url}\n  Error: _{error}_"
+
+
+def _format_restored_link(link: Dict[str, Any]) -> str:
+    doc_id = link.get("doc_id", "Unknown")
+    scheme_name = link.get("scheme_name", "Unknown")
+    link_url = link.get("link", "")
+    previous_error = link.get("previous_error", "Unknown")
+    return f"• *{scheme_name}*\n  ID: `{doc_id}`\n  Link: {link_url}\n  Previous error: _{previous_error}_"
+
+
+def _chunked_link_blocks(links: List[Dict[str, Any]], formatter: Callable[[Dict[str, Any]], str]) -> List[dict]:
+    """Group links into Slack section blocks, up to MAX_LINKS_PER_BLOCK per block."""
+    blocks = []
+    for i in range(0, len(links), MAX_LINKS_PER_BLOCK):
+        chunk = links[i : i + MAX_LINKS_PER_BLOCK]
+        text = "\n".join(formatter(link) for link in chunk)
+        blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": text}})
+    return blocks
+
+
+def _enforce_block_cap(blocks: List[dict]) -> List[dict]:
+    """Truncate blocks to Slack's 50-block limit, adding an overflow notice if truncated."""
+    if len(blocks) <= SLACK_MAX_BLOCKS:
+        return blocks
+    omitted = len(blocks) - (SLACK_MAX_BLOCKS - 1)
+    truncated = blocks[: SLACK_MAX_BLOCKS - 1]
+    truncated.append(
+        {
+            "type": "context",
+            "elements": [
+                {
+                    "type": "mrkdwn",
+                    "text": f":warning: _… and {omitted} more entries omitted. Check GCP logs for the full list._",
+                }
+            ],
+        }
+    )
+    return truncated
 
 
 def build_link_check_summary_message(
@@ -65,19 +115,7 @@ def build_link_check_summary_message(
                 "text": {"type": "mrkdwn", "text": f"*Restored Links ({len(restored_links)}) - previously inactive:*"},
             }
         )
-
-        for link in restored_links:
-            doc_id = link.get("doc_id", "Unknown")
-            scheme_name = link.get("scheme_name", "Unknown")
-            link_url = link.get("link", "")
-            previous_error = link.get("previous_error", "Unknown")
-
-            restored_text = (
-                f"• *{scheme_name}*\n  ID: `{doc_id}`\n  Link: {link_url}\n  Previous error: _{previous_error}_"
-            )
-
-            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": restored_text}})
-
+        blocks.extend(_chunked_link_blocks(restored_links, _format_restored_link))
         blocks.append(
             {
                 "type": "context",
@@ -91,18 +129,7 @@ def build_link_check_summary_message(
         blocks.append(
             {"type": "section", "text": {"type": "mrkdwn", "text": f"*Dead Links Detected ({len(dead_links)}):*"}}
         )
-
-        # Build dead links list - each as a separate section to avoid text limits
-        for link in dead_links:
-            doc_id = link.get("doc_id", "Unknown")
-            scheme_name = link.get("scheme_name", "Unknown")
-            link_url = link.get("link", "")
-            error = link.get("error", "Unknown error")
-
-            dead_link_text = f"• *{scheme_name}*\n  ID: `{doc_id}`\n  Link: {link_url}\n  Error: _{error}_"
-
-            blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": dead_link_text}})
-
+        blocks.extend(_chunked_link_blocks(dead_links, _format_dead_link))
         blocks.append(
             {
                 "type": "context",
@@ -129,7 +156,12 @@ def build_link_check_summary_message(
     if restored_count > 0:
         fallback_text += f", {restored_count} restored"
 
-    return {"text": fallback_text, "blocks": blocks, "unfurl_links": False, "unfurl_media": False}
+    return {
+        "text": fallback_text,
+        "blocks": _enforce_block_cap(blocks),
+        "unfurl_links": False,
+        "unfurl_media": False,
+    }
 
 
 def build_link_check_error_message(error: str) -> dict:

--- a/backend/functions/utils/reindex_embeddings.py
+++ b/backend/functions/utils/reindex_embeddings.py
@@ -40,9 +40,13 @@ def build_desc_booster(row) -> str:
         "scheme_type",
         "service_area",
     ]:
-        if pd.notna(row.get(field)):
-            value = row[field]
-            components.append(", ".join(value) if isinstance(value, list) else str(value))
+        value = row.get(field)
+        if isinstance(value, list):
+            items = [str(v).strip() for v in value if v is not None and str(v).strip()]
+            if items:
+                components.append(", ".join(items))
+        elif pd.notna(value) and str(value).strip():
+            components.append(str(value))
     return " ".join(components)
 
 

--- a/backend/tests/unit/test_link_check_slack_blocks.py
+++ b/backend/tests/unit/test_link_check_slack_blocks.py
@@ -1,0 +1,169 @@
+"""Unit tests for batch_jobs.slack_blocks.build_link_check_summary_message."""
+
+import pytest
+
+from batch_jobs.slack_blocks import build_link_check_summary_message
+
+
+def _dead_link(n: int) -> dict:
+    return {
+        "doc_id": f"doc-{n}",
+        "scheme_name": f"Scheme {n}",
+        "link": f"https://example.com/{n}",
+        "error": "HTTP 404",
+    }
+
+
+def _restored_link(n: int) -> dict:
+    return {
+        "doc_id": f"rdoc-{n}",
+        "scheme_name": f"Restored {n}",
+        "link": f"https://example.com/restored/{n}",
+        "previous_error": "HTTP 500",
+    }
+
+
+def _results(total: int, alive: int, dead: int, restored: int = 0) -> dict:
+    return {
+        "total_checked": total,
+        "alive_count": alive,
+        "dead_count": dead,
+        "restored_count": restored,
+        "duration_seconds": 60,
+    }
+
+
+def _reindex_success(indexed: int = 400) -> dict:
+    return {"success": True, "indexed_schemes": indexed, "skipped_inactive": 10}
+
+
+def test_block_count_never_exceeds_slack_limit_with_many_dead_links():
+    dead = [_dead_link(i) for i in range(80)]
+    msg = build_link_check_summary_message(
+        results=_results(500, 420, 80),
+        dead_links=dead,
+        reindex_result=_reindex_success(),
+    )
+    assert len(msg["blocks"]) <= 50
+
+
+def test_zero_links_produces_no_link_sections():
+    msg = build_link_check_summary_message(
+        results=_results(100, 100, 0),
+        dead_links=[],
+        reindex_result=_reindex_success(),
+    )
+    texts = [b.get("text", {}).get("text", "") for b in msg["blocks"] if b.get("type") == "section"]
+    assert not any("Dead Links Detected" in t for t in texts)
+    assert not any("Restored Links" in t for t in texts)
+
+
+def test_small_dead_list_fits_in_one_chunk_with_all_entries_visible():
+    dead = [_dead_link(i) for i in range(5)]
+    msg = build_link_check_summary_message(
+        results=_results(100, 95, 5),
+        dead_links=dead,
+        reindex_result=_reindex_success(),
+    )
+    all_text = "\n".join(b.get("text", {}).get("text", "") for b in msg["blocks"] if b.get("type") == "section")
+    for i in range(5):
+        assert f"Scheme {i}" in all_text
+        assert f"doc-{i}" in all_text
+
+
+def test_prod_shape_47_dead_and_4_restored_posts_all_entries_without_truncation():
+    dead = [_dead_link(i) for i in range(47)]
+    restored = [_restored_link(i) for i in range(4)]
+    msg = build_link_check_summary_message(
+        results=_results(494, 447, 47, restored=4),
+        dead_links=dead,
+        reindex_result=_reindex_success(),
+        restored_links=restored,
+    )
+    assert len(msg["blocks"]) <= 50
+    all_text = "\n".join(b.get("text", {}).get("text", "") for b in msg["blocks"] if b.get("type") == "section")
+    for i in range(47):
+        assert f"doc-{i}" in all_text
+    for i in range(4):
+        assert f"rdoc-{i}" in all_text
+    # No truncation notice for the prod shape
+    context_texts = [
+        el.get("text", "") for b in msg["blocks"] if b.get("type") == "context" for el in b.get("elements", [])
+    ]
+    assert not any("omitted" in t for t in context_texts)
+
+
+def test_huge_dead_list_produces_truncation_notice_citing_omitted_count():
+    dead = [_dead_link(i) for i in range(500)]
+    msg = build_link_check_summary_message(
+        results=_results(600, 100, 500),
+        dead_links=dead,
+        reindex_result=_reindex_success(),
+    )
+    assert len(msg["blocks"]) <= 50
+    # Last block should be a truncation notice
+    last = msg["blocks"][-1]
+    assert last["type"] == "context"
+    notice_text = last["elements"][0]["text"]
+    assert "omitted" in notice_text
+    assert "GCP logs" in notice_text
+
+
+@pytest.mark.parametrize("dead_count,restored_count", [(0, 0), (5, 0), (47, 4), (80, 0), (500, 0)])
+def test_every_section_text_stays_under_slack_3000_char_cap(dead_count, restored_count):
+    dead = [_dead_link(i) for i in range(dead_count)]
+    restored = [_restored_link(i) for i in range(restored_count)]
+    msg = build_link_check_summary_message(
+        results=_results(1000, 1000 - dead_count, dead_count, restored=restored_count),
+        dead_links=dead,
+        reindex_result=_reindex_success(),
+        restored_links=restored,
+    )
+    for block in msg["blocks"]:
+        if block.get("type") == "section":
+            assert len(block["text"]["text"]) <= 3000
+
+
+def test_restored_links_are_also_chunked_symmetrically():
+    # 80 restored should be chunked the same way as 80 dead would be
+    restored = [_restored_link(i) for i in range(80)]
+    msg = build_link_check_summary_message(
+        results=_results(500, 500, 0, restored=80),
+        dead_links=[],
+        reindex_result=_reindex_success(),
+        restored_links=restored,
+    )
+    assert len(msg["blocks"]) <= 50
+    # No restored doc id should be truncated if we're well under the 50 cap
+    # (80 restored / 10 per chunk = 8 chunks; plus header/summary/divider/header/context/reindex ≈ 14 blocks total)
+    all_text = "\n".join(b.get("text", {}).get("text", "") for b in msg["blocks"] if b.get("type") == "section")
+    for i in range(80):
+        assert f"rdoc-{i}" in all_text
+
+
+@pytest.mark.parametrize("dead_count,restored_count", [(0, 0), (5, 0), (47, 4), (80, 0), (500, 0)])
+def test_every_returned_block_has_valid_slack_shape(dead_count, restored_count):
+    dead = [_dead_link(i) for i in range(dead_count)]
+    restored = [_restored_link(i) for i in range(restored_count)]
+    msg = build_link_check_summary_message(
+        results=_results(1000, 1000 - dead_count, dead_count, restored=restored_count),
+        dead_links=dead,
+        reindex_result=_reindex_success(),
+        restored_links=restored,
+    )
+    for block in msg["blocks"]:
+        assert "type" in block
+        if block["type"] == "section":
+            assert "text" in block
+            assert block["text"].get("type") in ("mrkdwn", "plain_text")
+            assert isinstance(block["text"].get("text"), str)
+        elif block["type"] == "header":
+            assert block["text"]["type"] == "plain_text"
+            assert isinstance(block["text"]["text"], str)
+        elif block["type"] == "context":
+            assert "elements" in block
+            assert all("type" in el and "text" in el for el in block["elements"])
+        elif block["type"] == "divider":
+            pass
+        else:
+            raise AssertionError(f"Unexpected block type: {block['type']}")

--- a/backend/tests/unit/test_reindex_embeddings.py
+++ b/backend/tests/unit/test_reindex_embeddings.py
@@ -1,0 +1,62 @@
+"""Unit tests for utils.reindex_embeddings.build_desc_booster."""
+
+import pandas as pd
+
+from utils.reindex_embeddings import build_desc_booster
+
+
+def test_list_field_is_joined_with_comma_space():
+    row = pd.Series({"who_is_it_for": ["Elderly", "Caregivers"]})
+    assert build_desc_booster(row) == "Elderly, Caregivers"
+
+
+def test_scalar_string_is_passed_through():
+    row = pd.Series({"scheme": "Silver Support Scheme"})
+    assert build_desc_booster(row) == "Silver Support Scheme"
+
+
+def test_none_scalar_is_skipped():
+    row = pd.Series({"scheme": None})
+    assert build_desc_booster(row) == ""
+
+
+def test_nan_scalar_is_skipped():
+    row = pd.Series({"scheme": float("nan")})
+    assert build_desc_booster(row) == ""
+
+
+def test_empty_list_is_skipped():
+    row = pd.Series({"who_is_it_for": []})
+    assert build_desc_booster(row) == ""
+
+
+def test_list_filters_out_none_empty_and_whitespace_entries():
+    row = pd.Series({"who_is_it_for": [None, "", "  ", "Elderly"]})
+    assert build_desc_booster(row) == "Elderly"
+
+
+def test_row_missing_all_loop_fields_returns_empty_string():
+    row = pd.Series({"doc_id": "abc123", "unrelated_field": "ignored"})
+    assert build_desc_booster(row) == ""
+
+
+def test_realistic_mixed_row_combines_scalars_and_lists():
+    row = pd.Series(
+        {
+            "scheme": "Silver Support Scheme",
+            "agency": "CPF Board",
+            "llm_description": "Monthly payout for lower-income seniors.",
+            "who_is_it_for": ["Elderly", "Low-income"],
+            "what_it_gives": ["Monthly cash payout"],
+            "scheme_type": ["Financial Assistance"],
+            "service_area": "Singapore",
+        }
+    )
+    result = build_desc_booster(row)
+    assert "Silver Support Scheme" in result
+    assert "CPF Board" in result
+    assert "Monthly payout for lower-income seniors." in result
+    assert "Elderly, Low-income" in result
+    assert "Monthly cash payout" in result
+    assert "Financial Assistance" in result
+    assert "Singapore" in result


### PR DESCRIPTION
Closes #295
Closes #296

## Summary
Two independent bugs surfaced by the 2026-05-10 scheduled run of `scheduled_link_check_and_reindex`:

1. **Reindex crash** (#295): `build_desc_booster` called `pd.notna()` on list-valued Firestore fields, which returns an ndarray and raises `ValueError` when used in `if`. Reindex aborted mid-job.
2. **Slack block cap** (#296): Summary message appended one block per dead/restored link. 47 dead + 4 restored + overhead = ~60 blocks, over Slack's 50-block hard cap, so `chat.postMessage` returned `invalid_blocks` and no notification was sent.

## Changes
- `utils/reindex_embeddings.py`: type-branch on `isinstance(value, list)` before calling `pd.notna`; strict filter drops `None`, empty strings, and whitespace-only entries.
- `batch_jobs/slack_blocks.py`: chunk dead/restored links into section blocks (`MAX_LINKS_PER_BLOCK = 10`) via a shared helper; enforce `len(blocks) <= 50` with an overflow context block pointing to GCP logs.

## Test plan
- [x] `uv run pytest tests/unit/test_reindex_embeddings.py tests/unit/test_link_check_slack_blocks.py` — 24 tests pass, no regressions across the 43-test unit suite
- [x] Smoke test against dev Firestore (`schemessg-v3-dev`): reindex completes without `ValueError`, Slack posts successfully (`Slack notification sent`, no `invalid_blocks`)
- [x] Vector search sanity check: 5 semantic queries return correct top results against dev embeddings