### PR TITLE
fix: add missing scheme record id

### DIFF
--- a/backend/functions/utils/catalog_pagination.py
+++ b/backend/functions/utils/catalog_pagination.py
@@ -181,4 +181,8 @@ def get_paginated_results(
         next_cursor = _encode_cursor(docs[-1].id)
         docs = docs[:-1]
 
-    return PaginationResult(data=[doc.to_dict() for doc in docs], next_cursor=next_cursor, has_more=has_more)
+    return PaginationResult(
+        data=[{"scheme_id": doc.id, **doc.to_dict()} for doc in docs],
+        next_cursor=next_cursor,
+        has_more=has_more,
+    )


### PR DESCRIPTION
  **Problem**

  The catalog pagination endpoint (get_paginated_results in backend/functions/utils/catalog_pagination.py) returned each scheme's fields via doc.to_dict() but omitted the Firestore
  document ID. Clients consuming the catalog endpoint had no record identifier to reference a specific scheme.

  **Link to Issue:**

  N/A

  **Changes**

  - backend/functions/utils/catalog_pagination.py: Include doc.id alongside the document fields in the paginated response, so each item in data now contains an id key in addition to its
  Firestore fields.

  **Why**

  Downstream consumers (e.g. the frontend catalog) need a stable identifier per scheme to link to detail pages, deduplicate results, and reconcile updates. DocumentSnapshot.to_dict()
  does not include the document ID, so it had to be merged in explicitly.

  **Testing**

  Tested via DEV local backend.