### PR TITLE
feat: remap individual scheme types to subcategories

### DIFF
--- a/backend/functions/new_scheme/constants.py
+++ b/backend/functions/new_scheme/constants.py
@@ -121,6 +121,58 @@ SCHEME_TYPE = [
     "General Public Support",
 ]
 
+# TODO: Ideally, we should combine SCHEME_TYPE and SCHEME_CATEGORY_MAPPING into a single dictionary.
+# However, this would require some refactoring of the codebase.
+SCHEME_CATEGORY_MAPPING = {
+    "Financial Assistance": [
+        "Financial Assistance",
+        "Low Income",
+        "COVID-19 Support",
+    ],
+    "Family & Children": [
+        "Family",
+        "Children",
+        "Youth",
+        "Youth-at-Risk",
+        "Single Parents",
+        "Women",
+    ],
+    "Health & Wellbeing": [
+        "Healthcare",
+        "Mental Health",
+        "End-of-Life/Palliative Care",
+        "Counselling and Emotional Support",
+    ],
+    "Housing & Food": [
+        "Housing/Shelter",
+        "Food Support",
+    ],
+    "Education": [
+        "Education Support",
+    ],
+    "Employment & Training": [
+        "Employment Support",
+        "Vocational Training",
+        "Ex-offender Support",
+    ],
+    "Seniors & Caregiving": [
+        "Elderly",
+        "Caregiver Support",
+    ],
+    "Disability & Transport": [
+        "Persons with Disabilities (PWD)",
+        "Special Needs",
+        "Transport Support",
+    ],
+    "Legal & Safety": [
+        "Legal Aid",
+        "Abuse/Family Violence",
+    ],
+    "Community Support": [
+        "General Public Support",
+    ],
+}
+
 # =============================================================================
 # Logo Detection Patterns
 # =============================================================================

--- a/backend/functions/schemes/catalog.py
+++ b/backend/functions/schemes/catalog.py
@@ -5,7 +5,7 @@ URL for local testing:
 http://127.0.0.1:5001/schemessg-v3-dev/asia-southeast1/catalog
 http://127.0.0.1:5001/schemessg-v3-dev/asia-southeast1/catalog?agency=<agency>
 http://127.0.0.1:5001/schemessg-v3-dev/asia-southeast1/catalog?area=<area>
-http://127.0.0.1:5001/schemessg-v3-dev/asia-southeast1/catalog?scheme_type=<scheme_type>
+http://127.0.0.1:5001/schemessg-v3-dev/asia-southeast1/catalog?category=<category>
 """
 
 import json
@@ -16,7 +16,7 @@ from fb_manager.firebaseManager import FirebaseManager
 from firebase_functions import https_fn, options
 from google.cloud.firestore_v1 import FieldFilter
 from loguru import logger
-from new_scheme.constants import SCHEME_TYPE
+from new_scheme.constants import SCHEME_CATEGORY_MAPPING
 from utils.auth import verify_auth_token
 from utils.catalog_pagination import PaginationResult, get_paginated_results
 from utils.cors_config import get_cors_headers, handle_cors_preflight
@@ -33,7 +33,7 @@ class CatalogFilterSpec:
 
     firestore_field: str
     operator: str
-    normalize: Callable[[str], str]
+    normalize: Callable[[str], str | list[str]]
 
 
 @dataclass(kw_only=True)
@@ -43,17 +43,43 @@ class CatalogRequestParams:
     limit: int = DEFAULT_LIMIT
     cursor: str | None = None
     filter_name: str | None = None
-    filter_value: str | None = None
+    filter_value: str | list[str] | None = None
 
 
-_SCHEME_TYPE_LOOKUP = {st.lower(): st for st in SCHEME_TYPE}
+_CATEGORY_LOOKUP = {cat.lower(): types for cat, types in SCHEME_CATEGORY_MAPPING.items()}
 
 
-def _normalize_scheme_type(value: str) -> str:
-    canonical = _SCHEME_TYPE_LOOKUP.get(value.lower())
-    if canonical is None:
-        raise ValueError(f"Unknown scheme_type: '{value}'")
-    return canonical
+def _expand_category(value: str) -> list[str]:
+    types = _CATEGORY_LOOKUP.get(value.lower())
+    if types is None:
+        raise ValueError(f"Unknown category: '{value}'")
+    return types
+
+
+def _filter_scheme_types_for_category(results: PaginationResult, category_scheme_types: list[str]) -> PaginationResult:
+    """Trim scheme_type values in category catalog responses to the matched category."""
+
+    category_scheme_type_set = set(category_scheme_types)
+    filtered_data = []
+
+    for item in results.data:
+        scheme_type = item.get("scheme_type")
+        if not isinstance(scheme_type, list):
+            filtered_data.append(item)
+            continue
+
+        filtered_data.append(
+            {
+                **item,
+                "scheme_type": [value for value in scheme_type if value in category_scheme_type_set],
+            }
+        )
+
+    return PaginationResult(
+        data=filtered_data,
+        next_cursor=results.next_cursor,
+        has_more=results.has_more,
+    )
 
 
 FILTER_SPECS = {
@@ -67,10 +93,10 @@ FILTER_SPECS = {
         operator="array_contains",
         normalize=lambda value: value.upper(),
     ),
-    "scheme_type": CatalogFilterSpec(
+    "category": CatalogFilterSpec(
         firestore_field="scheme_type",
-        operator="array_contains",
-        normalize=_normalize_scheme_type,
+        operator="array_contains_any",
+        normalize=_expand_category,
     ),
 }
 ALLOWED_QUERY_PARAMS = set(FILTER_SPECS) | {"limit", "cursor", "is_warmup", "sort"}
@@ -188,7 +214,7 @@ def _parse_query_params(query_params: MultiDict[str, str]) -> CatalogRequestPara
       - /catalog
       - /catalog?agency=<name>
       - /catalog?area=<name>
-      - /catalog?scheme_type=<name>
+      - /catalog?category=<name>
 
     Raises:
         ValueError: If unsupported query parameters are provided.
@@ -252,9 +278,14 @@ def _handle_catalog_request(
     spec = FILTER_SPECS[query_params.filter_name]
     query = col.where(filter=FieldFilter(spec.firestore_field, spec.operator, query_params.filter_value))
 
-    return get_paginated_results(
+    results = get_paginated_results(
         collection_ref=col,
         base_query=query,
         cursor=query_params.cursor,
         limit=query_params.limit,
     )
+
+    if query_params.filter_name == "category" and isinstance(query_params.filter_value, list):
+        return _filter_scheme_types_for_category(results, query_params.filter_value)
+
+    return results

--- a/backend/test-endpoint.http
+++ b/backend/test-endpoint.http
@@ -50,17 +50,47 @@ GET {{base}}/catalog?area=choa+chu+kang&limit=1&cursor=
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
-### Retrieve all schemes by scheme type
-GET {{base}}/catalog?scheme_type=healthcare
+### Retrieve schemes by category (e.g., Healthcare)
+GET {{base}}/catalog?category=healthcare
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
-### Retrieve all schemes by scheme type with limit
-GET {{base}}/catalog?scheme_type=healthcare&limit=2
+### Retrieve schemes by category with limit
+GET {{base}}/catalog?category=healthcare&limit=2
 Authorization: Bearer {{token}}
 Content-Type: application/json
 
-### Retrieve all schemes by scheme type with limit and cursor
-GET {{base}}/catalog?scheme_type=healthcare&limit=1&cursor=
+### Retrieve schemes by category with limit and cursor
+GET {{base}}/catalog?category=healthcare&limit=1&cursor=
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+### Retrieve schemes by category - Financial Assistance
+GET {{base}}/catalog?category=financial+assistance
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+### Retrieve schemes by category - Family
+GET {{base}}/catalog?category=family
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+### Retrieve schemes by category - Employment
+GET {{base}}/catalog?category=employment
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+### Retrieve schemes by category - Eldercare
+GET {{base}}/catalog?category=eldercare
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+### Retrieve schemes by category - Disability
+GET {{base}}/catalog?category=disability
+Authorization: Bearer {{token}}
+Content-Type: application/json
+
+### Invalid category - expect 400
+GET {{base}}/catalog?category=unknown
 Authorization: Bearer {{token}}
 Content-Type: application/json

--- a/backend/tests/integration/test_catalog.py
+++ b/backend/tests/integration/test_catalog.py
@@ -1,7 +1,9 @@
 """Tests for the catalog endpoint."""
 
 import json
+from collections import Counter
 
+from new_scheme.constants import SCHEME_CATEGORY_MAPPING, SCHEME_TYPE
 from schemes.catalog import CatalogRequestParams, _handle_catalog_request, _parse_query_params, catalog
 from utils.catalog_pagination import PaginationResult
 from werkzeug.datastructures import MultiDict
@@ -36,11 +38,11 @@ def test_catalog_invalid_method(mock_request, mock_https_response, mock_auth, mo
 
 
 def test_catalog_invalid_query(mock_request, mock_https_response, mock_auth, mocker):
-    """Test catalog endpoint with invalid query parameters."""
+    """Test catalog endpoint with multiple filters supplied together."""
     mock_manager = mocker.MagicMock()
     mocker.patch("schemes.catalog.create_firebase_manager", return_value=mock_manager)
 
-    request = mock_request(method="GET", args={"area": "TAMPINES", "scheme_type": "healthcare"})
+    request = mock_request(method="GET", args={"area": "TAMPINES", "category": "health & wellbeing"})
 
     response = catalog(request)
 
@@ -49,8 +51,8 @@ def test_catalog_invalid_query(mock_request, mock_https_response, mock_auth, moc
     assert "Error parsing query parameters" in response_data["error"]
 
 
-def test_catalog_successful_scheme_type_fetch(mock_request, mock_https_response, mock_auth, mocker):
-    """Test successful catalog fetch with scheme_type filtering."""
+def test_catalog_successful_category_fetch(mock_request, mock_https_response, mock_auth, mocker):
+    """Test successful catalog fetch with category filtering."""
     mock_collection = mocker.MagicMock()
     mock_query = mocker.MagicMock()
     mock_collection.where.return_value = mock_query
@@ -59,28 +61,33 @@ def test_catalog_successful_scheme_type_fetch(mock_request, mock_https_response,
     mock_manager.firestore_client.collection.return_value = mock_collection
 
     mocker.patch("schemes.catalog.create_firebase_manager", return_value=mock_manager)
-    field_filter = mocker.patch("schemes.catalog.FieldFilter", return_value="scheme-type-filter")
+    field_filter = mocker.patch("schemes.catalog.FieldFilter", return_value="category-filter")
     mocker.patch(
         "schemes.catalog.get_paginated_results",
         return_value=PaginationResult(
-            data=[{"scheme_name": "Test Scheme", "scheme_type": ["healthcare"]}],
+            data=[{"scheme_name": "Test Scheme", "scheme_type": ["Children", "Caregiver Support"]}],
             next_cursor="next-page",
             has_more=True,
         ),
     )
 
-    request = mock_request(method="GET", args={"scheme_type": "healthcare", "limit": "2"})
+    request = mock_request(method="GET", args={"category": "seniors & caregiving", "limit": "2"})
 
     response = catalog(request)
 
     assert response.status_code == 200
     response_data = json.loads(response.get_data())
     assert response_data["data"][0]["scheme_name"] == "Test Scheme"
+    assert response_data["data"][0]["scheme_type"] == ["Caregiver Support"]
     assert response_data["next_cursor"] == "next-page"
     assert response_data["has_more"] is True
     mock_manager.firestore_client.collection.assert_called_once_with("schemes")
-    field_filter.assert_called_once_with("scheme_type", "array_contains", "Healthcare")
-    mock_collection.where.assert_called_once_with(filter="scheme-type-filter")
+    field_filter.assert_called_once_with(
+        "scheme_type",
+        "array_contains_any",
+        ["Elderly", "Caregiver Support"],
+    )
+    mock_collection.where.assert_called_once_with(filter="category-filter")
 
 
 def test_catalog_not_found(mock_request, mock_https_response, mock_auth, mocker):
@@ -89,7 +96,7 @@ def test_catalog_not_found(mock_request, mock_https_response, mock_auth, mocker)
     mocker.patch("schemes.catalog.create_firebase_manager", return_value=mock_manager)
     mocker.patch("schemes.catalog.get_paginated_results", return_value=PaginationResult(data=[]))
 
-    request = mock_request(method="GET", args={"scheme_type": "healthcare"})
+    request = mock_request(method="GET", args={"category": "health & wellbeing"})
 
     response = catalog(request)
 
@@ -107,9 +114,9 @@ def test_catalog_firestore_error(mock_request, mock_https_response, mock_auth, m
     mock_manager.firestore_client.collection.return_value = mock_collection
 
     mocker.patch("schemes.catalog.create_firebase_manager", return_value=mock_manager)
-    mocker.patch("schemes.catalog.FieldFilter", return_value="scheme-type-filter")
+    mocker.patch("schemes.catalog.FieldFilter", return_value="category-filter")
 
-    request = mock_request(method="GET", args={"scheme_type": "healthcare"})
+    request = mock_request(method="GET", args={"category": "health & wellbeing"})
 
     response = catalog(request)
 
@@ -128,13 +135,18 @@ def test_catalog_cors_preflight(mock_request, mock_https_response, mock_auth, mo
     assert response.headers.get("Access-Control-Allow-Origin") == "http://localhost:3000"
 
 
-def test_parse_query_params_scheme_type():
-    """Parse a scheme_type catalog request."""
-    params = _parse_query_params(MultiDict([("scheme_type", "healthcare"), ("limit", "5"), ("cursor", "abc")]))
+def test_parse_query_params_category():
+    """Parse a category catalog request."""
+    params = _parse_query_params(MultiDict([("category", "health & wellbeing"), ("limit", "5"), ("cursor", "abc")]))
 
     assert isinstance(params, CatalogRequestParams)
-    assert params.filter_name == "scheme_type"
-    assert params.filter_value == "Healthcare"
+    assert params.filter_name == "category"
+    assert params.filter_value == [
+        "Healthcare",
+        "Mental Health",
+        "End-of-Life/Palliative Care",
+        "Counselling and Emotional Support",
+    ]
     assert params.limit == 5
     assert params.cursor == "abc"
 
@@ -142,52 +154,125 @@ def test_parse_query_params_scheme_type():
 def test_parse_query_params_rejects_multiple_filters():
     """Reject requests that mix catalog filter types."""
     try:
-        _parse_query_params(MultiDict([("area", "TAMPINES"), ("scheme_type", "healthcare")]))
+        _parse_query_params(MultiDict([("area", "TAMPINES"), ("category", "health & wellbeing")]))
         assert False, "Expected ValueError for multiple filters"
     except ValueError as exc:
-        assert "'area', 'scheme_type'" in str(exc)
+        assert "'area', 'category'" in str(exc)
 
 
-def test_parse_query_params_normalizes_scheme_type_casing():
-    """Normalize scheme_type with mixed casing (e.g. housing/shelter)."""
-    params = _parse_query_params(MultiDict([("scheme_type", "housing/shelter")]))
-    assert params.filter_value == "Housing/Shelter"
+def test_parse_query_params_category_lookup_is_case_insensitive():
+    """Category lookup accepts any casing from the client."""
+    params = _parse_query_params(MultiDict([("category", "HEALTH & WELLBEING")]))
+    assert params.filter_value == [
+        "Healthcare",
+        "Mental Health",
+        "End-of-Life/Palliative Care",
+        "Counselling and Emotional Support",
+    ]
 
 
-def test_parse_query_params_rejects_unknown_scheme_type():
-    """Reject unknown scheme_type values."""
+def test_category_mapping_covers_each_scheme_type_once():
+    """Every raw scheme_type is assigned to exactly one public category."""
+    mapped_types = [scheme_type for values in SCHEME_CATEGORY_MAPPING.values() for scheme_type in values]
+
+    assert set(mapped_types) == set(SCHEME_TYPE)
+    assert Counter(mapped_types) == Counter(SCHEME_TYPE)
+
+
+def test_category_mapping_has_no_duplicate_scheme_types():
+    """No raw scheme_type appears in more than one public category."""
+    mapped_types = [scheme_type for values in SCHEME_CATEGORY_MAPPING.values() for scheme_type in values]
+    duplicate_types = [scheme_type for scheme_type, count in Counter(mapped_types).items() if count > 1]
+
+    assert duplicate_types == []
+
+
+def test_parse_query_params_rejects_unknown_category():
+    """Reject unknown category values."""
     try:
-        _parse_query_params(MultiDict([("scheme_type", "bogus")]))
-        assert False, "Expected ValueError for unknown scheme_type"
+        _parse_query_params(MultiDict([("category", "bogus")]))
+        assert False, "Expected ValueError for unknown category"
     except ValueError as exc:
-        assert "Unknown scheme_type" in str(exc)
+        assert "Unknown category" in str(exc)
 
 
-def test_handle_catalog_request_uses_array_contains_for_scheme_type(mocker, mock_firebase_manager):
-    """Build a Firestore array_contains query for scheme_type."""
+def test_handle_catalog_request_uses_array_contains_any_for_category(mocker, mock_firebase_manager):
+    """Build a Firestore array_contains_any query for category."""
     mock_collection = mocker.MagicMock()
     mock_query = mocker.MagicMock()
     mock_collection.where.return_value = mock_query
     mock_firebase_manager.firestore_client.collection.return_value = mock_collection
 
-    field_filter = mocker.patch("schemes.catalog.FieldFilter", return_value="scheme-type-filter")
-    get_paginated_results = mocker.patch("schemes.catalog.get_paginated_results")
+    field_filter = mocker.patch("schemes.catalog.FieldFilter", return_value="category-filter")
+    get_paginated_results = mocker.patch(
+        "schemes.catalog.get_paginated_results",
+        return_value=PaginationResult(
+            data=[{"scheme_name": "Test Scheme", "scheme_type": ["Children", "Caregiver Support"]}],
+            next_cursor="next-page",
+            has_more=True,
+        ),
+    )
 
     query_params = CatalogRequestParams(
-        filter_name="scheme_type",
-        filter_value="Healthcare",
+        filter_name="category",
+        filter_value=["Elderly", "Caregiver Support"],
         limit=3,
         cursor="next-page",
     )
 
-    _handle_catalog_request(mock_firebase_manager, query_params)
+    results = _handle_catalog_request(mock_firebase_manager, query_params)
 
     mock_firebase_manager.firestore_client.collection.assert_called_once_with("schemes")
-    field_filter.assert_called_once_with("scheme_type", "array_contains", "Healthcare")
-    mock_collection.where.assert_called_once_with(filter="scheme-type-filter")
+    field_filter.assert_called_once_with(
+        "scheme_type",
+        "array_contains_any",
+        ["Elderly", "Caregiver Support"],
+    )
+    mock_collection.where.assert_called_once_with(filter="category-filter")
     get_paginated_results.assert_called_once_with(
         collection_ref=mock_collection,
         base_query=mock_query,
         cursor="next-page",
         limit=3,
     )
+    assert results.data == [{"scheme_name": "Test Scheme", "scheme_type": ["Caregiver Support"]}]
+    assert results.next_cursor == "next-page"
+    assert results.has_more is True
+
+
+def test_handle_catalog_request_preserves_scheme_types_for_area_filter(mocker, mock_firebase_manager):
+    """Only category catalog requests trim scheme_type values."""
+    mock_collection = mocker.MagicMock()
+    mock_query = mocker.MagicMock()
+    mock_collection.where.return_value = mock_query
+    mock_firebase_manager.firestore_client.collection.return_value = mock_collection
+
+    field_filter = mocker.patch("schemes.catalog.FieldFilter", return_value="area-filter")
+    get_paginated_results = mocker.patch(
+        "schemes.catalog.get_paginated_results",
+        return_value=PaginationResult(
+            data=[{"scheme_name": "Test Scheme", "scheme_type": ["Children", "Caregiver Support"]}],
+            next_cursor="next-page",
+            has_more=True,
+        ),
+    )
+
+    query_params = CatalogRequestParams(
+        filter_name="area",
+        filter_value="TAMPINES",
+        limit=3,
+        cursor="next-page",
+    )
+
+    results = _handle_catalog_request(mock_firebase_manager, query_params)
+
+    field_filter.assert_called_once_with("planning_area", "array_contains", "TAMPINES")
+    get_paginated_results.assert_called_once_with(
+        collection_ref=mock_collection,
+        base_query=mock_query,
+        cursor="next-page",
+        limit=3,
+    )
+    assert results.data == [{"scheme_name": "Test Scheme", "scheme_type": ["Children", "Caregiver Support"]}]
+    assert results.next_cursor == "next-page"
+    assert results.has_more is True


### PR DESCRIPTION
  **Problem**

  The catalog endpoint previously accepted scheme_type as a filter parameter, which required
   the frontend to pass individual Firestore scheme type values (e.g. "Mental Health",
  "Counselling and Emotional Support"). This made filtering cumbersome as related scheme
  types were not grouped, and the FE had no clean way to filter by broader category (e.g.
  all types under "Mental Health").

  **Link to Issue:**

  N/A. Requirements from FE (@kairayzo)

  **Changes**

  - Added SCHEME_CATEGORY_MAPPING in constants.py that maps 10 top-level categories (e.g.
  Financial Assistance, Healthcare, Family) to their constituent individual scheme types.
  - Replaced the scheme_type query parameter on the /catalog endpoint with a category
  parameter.
  - The category filter now uses Firestore's array_contains_any operator, expanding the
  requested category into all its mapped scheme types before querying.
  - Updated integration tests and the .http test file to reflect the new parameter and
  category values.

  **Why**

  Grouping granular scheme types under broader categories simplifies the FE filtering UI —
  the FE can now pass a single human-readable category (e.g. ?category=eldercare) instead of
   having to know and pass individual scheme type strings. The mapping lives on the BE,
  keeping the FE decoupled from Firestore data structure details.

**Testing**

Tested on BE via request calls.
