### PR TITLE
chore: dependabot config for deps upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "stg"
+    open-pull-requests-limit: 3
+    groups:
+      gha-deps:
+        patterns:
+          - "*"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "stg"
+    open-pull-requests-limit: 3
+    groups:
+      npm-deps:
+        patterns:
+          - "*"
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    target-branch: "stg"
+    open-pull-requests-limit: 3
+    groups:
+      python-deps:
+        patterns:
+          - "*"


### PR DESCRIPTION
**Problem**

Dependabot config for auto upgrades of GHA, python and NPM deps.

**Link to Issue:**

NA

**Changes**

Dependabot will auto-create PR's to `stg` branch for deps upgrades. One PR to combine deps upgrades for each type e.g. one PR for upgrading all NPM deps.

**Why**

Fix security vulnerabilities in deps.

**Testing**

This change doesnt impact the app codebase.
