### PR TITLE
Fix Firebase staging deploy: allow legacy peer deps

### DIFF
--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,7 @@
+# Firebase Hosting's web-frameworks adapter builds an SSR Cloud Function and runs
+# `npm i` on a generated package that depends on firebase-frameworks, whose
+# optional peer is sharp@^0.32||^0.33. Next 16 / this project use sharp@^0.34,
+# so strict peer resolution aborts that install (ERESOLVE) and the deploy fails.
+# sharp's optional peer is only image-optimization glue and 0.34 is compatible,
+# so allow the install to proceed.
+legacy-peer-deps=true


### PR DESCRIPTION
**Problem**

The Firebase Hosting (staging) deploy fails at the `FirebaseExtended/action-hosting-deploy` step. The Next.js build succeeds, but because the app is SSR (`output: standalone`, dynamic `/schemes/[schemeId]` route, `revalidate` on `/sitemap.xml`), Firebase's web-frameworks adapter builds a Cloud Function and runs `npm i --omit dev --no-audit` on a generated package that depends on `firebase-frameworks`.

That install aborts with `ERESOLVE`:

```
While resolving: firebase-frameworks@0.11.8
Found: sharp@0.34.5 (from next@16 and our package.json)
Could not resolve: peerOptional sharp@"^0.32 || ^0.33" from firebase-frameworks@0.11.8
```

Strict npm peer resolution rejects `sharp@0.34` against `firebase-frameworks`' `^0.32 || ^0.33` peer, so the deploy exits with code 2.

**Changes**

- Added `frontend/.npmrc` with `legacy-peer-deps=true`. Firebase's generated SSR install picks this up and proceeds past the (harmless, optional) `sharp` peer mismatch.

**Why**

`sharp` is `next@16`'s own optional image-optimization peer and 0.34 is compatible; the conflict is only `firebase-frameworks`' stale optional peer range. We keep `sharp@^0.34.5` (what Next wants) and relax the strict peer check rather than downgrade. `npm ci` is unaffected — it installs from the lockfile.

**Testing**

- Confirmed the failing run's error is the `firebase-frameworks` ↔ `sharp` peer `ERESOLVE` during the SSR function install.
- Verified `npm ci --dry-run` still resolves cleanly with the `.npmrc` in place.