### PR TITLE
Fix mobile landing overflow and composer height

### DIFF
--- a/frontend/src/app/(main)/layout.tsx
+++ b/frontend/src/app/(main)/layout.tsx
@@ -11,7 +11,7 @@ export default function MainLayout({
     <>
       <Navbar />
       <div className="h-[var(--schemes-mobile-nav-offset)] transition-[height] duration-300 md:h-nav"></div>
-      <main className="h-[calc(100vh-var(--schemes-mobile-nav-offset))] transition-[height] duration-300 md:h-[calc(100vh-var(--spacing-nav))]">
+      <main className="h-[calc(100dvh-var(--schemes-mobile-nav-offset))] transition-[height] duration-300 md:h-[calc(100dvh-var(--spacing-nav))]">
         {children}
       </main>
     </>

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -94,7 +94,7 @@ export default function RootLayout({
         }}
       >
         <AppProviders>
-          <div className="h-full min-h-screen">{children}</div>
+          <div className="h-full min-h-dvh">{children}</div>
         </AppProviders>
       </body>
     </html>

--- a/frontend/src/components/chat/chat-landing.tsx
+++ b/frontend/src/components/chat/chat-landing.tsx
@@ -17,9 +17,16 @@ export default function ChatLanding() {
   // tall enough, but scrolls from the top (with padding) on short screens
   // instead of overflowing upward under the fixed navbar.
   return (
-    <div className="grain-overlay flex h-full w-full flex-col overflow-y-auto bg-neutral-50">
-      <div className="pointer-events-none absolute bottom-[10%] left-[10%] h-[600px] w-[600px] rounded-full bg-amber-300/10 blur-[120px]" />
-      <div className="pointer-events-none absolute top-[10%] right-[5%] h-[600px] w-[600px] rounded-full bg-blue-300/20 blur-[120px]" />
+    <div className="grain-overlay relative flex h-full w-full flex-col overflow-y-auto bg-neutral-50">
+      {/* Decorative glow orbs, clipped to the viewport in their own layer so the
+          600px blobs can't create horizontal scroll room on narrow screens. */}
+      <div
+        aria-hidden="true"
+        className="pointer-events-none absolute inset-0 overflow-hidden"
+      >
+        <div className="absolute bottom-[10%] left-[10%] h-[600px] w-[600px] rounded-full bg-amber-300/10 blur-[120px]" />
+        <div className="absolute top-[10%] right-[5%] h-[600px] w-[600px] rounded-full bg-blue-300/20 blur-[120px]" />
+      </div>
       <div className="my-auto flex w-full justify-center py-8">
         <ChatLandingInput
           query={draftMessage}

--- a/frontend/src/hooks/use-auto-grow-textarea.ts
+++ b/frontend/src/hooks/use-auto-grow-textarea.ts
@@ -33,10 +33,20 @@ export function useAutoGrowTextarea(
     const el = ref.current;
     if (!el) return;
     const cap = expanded ? expandedMaxHeight : collapsedMaxHeight;
-    // Measure natural content height by collapsing first, then clamp to the cap.
-    el.style.height = "auto";
+    // Measure the true height of the actual VALUE. Two things would otherwise
+    // inflate scrollHeight and wrongly flag the composer as multi-line:
+    //   - a CSS min-height (reads as an extra line on some high-DPR mobile);
+    //   - a long placeholder that wraps to 2 lines on a narrow textarea.
+    // Neutralise both, collapse to 0, measure, then restore.
+    const prevMinHeight = el.style.minHeight;
+    const placeholder = el.placeholder;
+    el.placeholder = "";
+    el.style.minHeight = "0px";
+    el.style.height = "0px";
     const natural = el.scrollHeight;
     el.style.height = Math.min(natural, cap) + "px";
+    el.style.minHeight = prevMinHeight;
+    el.placeholder = placeholder;
     setMultiline(natural > lineHeight + 1);
     // The expand affordance is only meaningful once content exceeds the
     // collapsed cap (i.e. there's more to reveal than the collapsed view shows).


### PR DESCRIPTION
**Problem**

Two mobile-only issues on the landing/chat experience:

1. The landing page had a horizontal scroll — a band of empty space to the right that you could swipe to. The decorative 600px glow orbs were bleeding past the viewport inside the scroll container.
2. The landing search bar rendered as a rounded rectangle instead of a pill, because the long placeholder wrapped to two lines on a narrow textarea and the auto-grow hook counted the wrapped placeholder as real content (flagging "multi-line").
3. After sending a query, the composer (search bar) could sit below the fold and the view didn't scroll to reveal it — the panel used `100vh`, which on mobile is the toolbar-collapsed height and exceeds the visible area.

**Changes**

- Wrapped the landing glow orbs in a clipped `absolute inset-0 overflow-hidden` layer so the blobs can't create horizontal scroll room on narrow screens.
- Auto-grow composer hook now blanks the placeholder (and min-height) while measuring true content height, so an empty field stays single-line and the composer keeps its pill shape on mobile.
- Switched the app height from `100vh` / `min-h-screen` to the dynamic viewport (`100dvh` / `min-h-dvh`) so the chat panel matches the visible area and the composer stays in view as the mobile browser toolbar shows/hides.

**Why**

Mobile is the primary surface for this audience. The horizontal scroll and off-screen composer made the core search flow feel broken on phones.

**Testing**

- Reproduced and fixed the landing horizontal overflow at 390px (no horizontal scroll possible; `scrollWidth === clientWidth`).
- Confirmed the empty composer measures one line and renders as a pill on mobile; long input still expands to the rounded-rectangle form.
- Verified the chat layout fits the visible viewport with the composer and follow-up chips at the bottom. The `dvh` change is the standard fix for the `100vh` mobile-toolbar gap (matches DESIGN.md's "prefer min-h-dvh" guidance).
- Type checks pass.