### PR TITLE
Fix catalog index __name__ direction to DESCENDING

### DIFF
--- a/backend/firestore.indexes.json
+++ b/backend/firestore.indexes.json
@@ -27,7 +27,7 @@
         },
         {
           "fieldPath": "__name__",
-          "order": "ASCENDING"
+          "order": "DESCENDING"
         }
       ]
     },
@@ -45,7 +45,7 @@
         },
         {
           "fieldPath": "__name__",
-          "order": "ASCENDING"
+          "order": "DESCENDING"
         }
       ]
     },
@@ -63,7 +63,7 @@
         },
         {
           "fieldPath": "__name__",
-          "order": "ASCENDING"
+          "order": "DESCENDING"
         }
       ]
     }


### PR DESCRIPTION
## Why

Fixes the prod catalog outage tracked in #340: catalog category/area filters returned 0 ("No schemes found") while "All" worked.

Root cause was in `backend/firestore.indexes.json` itself: the three `schemes` filter indexes declared `__name__: ASCENDING`. The catalog query orders by `last_scraped_update DESCENDING`, and Firestore implicitly appends `__name__` in the **same direction as the last `orderBy`** (DESC). An index with `__name__ ASCENDING` therefore never serves the query — it fails with `FailedPrecondition: requires an index` even though an index "exists".

Dev worked because its indexes were created via the console error-link (which always generates the matching DESC direction); that correct direction was never written back into the committed JSON.

## Change

Flip `__name__` from `ASCENDING` → `DESCENDING` on the three `schemes` composite indexes (`scheme_type`, `planning_area`, `agency`). Now matches dev's serving indexes exactly.

## Prod status (already applied)

To stop the live outage, the corrected indexes were already deployed to prod and verified:

- Deployed `firestore.indexes.json` (DESC) to `schemessg`; all 3 built to READY.
- Verified live: `category Family & Children` → 20, `category Financial Assistance` → 20, `area BISHAN` → 5.
- Deleted the 3 stale ASC indexes from prod so it matches this file.

This PR brings the repo in line with what's now on prod, and flows the fix to `main`/prod through the normal release.

## Follow-up (separate)

CI deploys functions + hosting but never `firebase deploy --only firestore:indexes`, which is why prod drifted. A deploy step / release-checklist item should be added so index changes reach prod automatically (noted in #340).

Closes #340
