### PR TITLE
Fix scheme contact display (strings, No Location, junk emails)

### DIFF
--- a/frontend/src/lib/schemes.ts
+++ b/frontend/src/lib/schemes.ts
@@ -52,35 +52,62 @@ const splitCsv = (value?: string | null): string[] | undefined => {
   return parts.length ? parts : undefined;
 };
 
+// "No Location" is a placeholder the dataset uses when a scheme has no real
+// planning area. Treat it as "no label" rather than rendering a literal
+// "NO LOCATION" card.
+const cleanPlanningArea = (value?: string): string | undefined =>
+  value && value !== "No Location" ? value : undefined;
+
+// Some scraped sources obfuscate emails (e.g. Joomla/CleanTalk), so the scraper
+// captured placeholder text like "This email address is being protected from
+// spambots..." instead of a real address. Drop anything that isn't a plausible
+// email so it never renders as a broken mailto link.
+const isRealEmail = (value: string): boolean =>
+  /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value.trim());
+
+const cleanEmails = (emails?: string[]): string[] | undefined => {
+  const valid = emails?.filter(isRealEmail);
+  return valid && valid.length ? valid : undefined;
+};
+
 const buildContacts = (raw: RawScheme): BranchContact[] => {
   const planningAreas = Array.isArray(raw.planning_area)
     ? raw.planning_area
-    : raw.planning_area && raw.planning_area !== "No Location"
+    : raw.planning_area
       ? [raw.planning_area]
       : undefined;
 
   if (planningAreas) {
+    const fieldCount = (value?: string | string[] | null) =>
+      Array.isArray(value) ? value.length : value ? 1 : 0;
     const maxContacts = Math.max(
-      Array.isArray(raw.phone) ? raw.phone.length : 0,
-      Array.isArray(raw.email) ? raw.email.length : 0,
-      Array.isArray(raw.address) ? raw.address.length : 0,
+      fieldCount(raw.phone),
+      fieldCount(raw.email),
+      fieldCount(raw.address),
     );
 
     if (maxContacts === 0) {
-      return Array.from(new Set(planningAreas)).map((planningArea) => ({
-        planningArea,
-        phones: undefined,
-        emails: undefined,
-        address: undefined,
-      }));
+      // No contact details at all — only keep real planning-area labels, and
+      // drop entries that would render an empty/"No Location" card.
+      return Array.from(new Set(planningAreas))
+        .map(cleanPlanningArea)
+        .filter((planningArea): planningArea is string => Boolean(planningArea))
+        .map((planningArea) => ({
+          planningArea,
+          phones: undefined,
+          emails: undefined,
+          address: undefined,
+        }));
     }
 
     if (planningAreas.length === 1) {
       return [
         {
-          planningArea: planningAreas[0],
+          planningArea: cleanPlanningArea(planningAreas[0]),
           phones: Array.isArray(raw.phone) ? raw.phone : splitCsv(raw.phone),
-          emails: Array.isArray(raw.email) ? raw.email : splitCsv(raw.email),
+          emails: cleanEmails(
+            Array.isArray(raw.email) ? raw.email : splitCsv(raw.email),
+          ),
           address: Array.isArray(raw.address)
             ? raw.address[0]
             : (raw.address ?? undefined),
@@ -96,9 +123,9 @@ const buildContacts = (raw: RawScheme): BranchContact[] => {
         : raw.address;
 
       return {
-        planningArea,
+        planningArea: cleanPlanningArea(planningArea),
         phones: splitCsv(phone),
-        emails: splitCsv(email),
+        emails: cleanEmails(splitCsv(email)),
         address: address || undefined,
       };
     });
@@ -107,8 +134,8 @@ const buildContacts = (raw: RawScheme): BranchContact[] => {
   const phones = splitCsv(
     Array.isArray(raw.phone) ? raw.phone.join(",") : raw.phone,
   );
-  const emails = splitCsv(
-    Array.isArray(raw.email) ? raw.email.join(",") : raw.email,
+  const emails = cleanEmails(
+    splitCsv(Array.isArray(raw.email) ? raw.email.join(",") : raw.email),
   );
   const address = Array.isArray(raw.address) ? raw.address[0] : raw.address;
 


### PR DESCRIPTION
## Why

The scheme detail "Agency details" card was dropping or garbling contact info. Fixes the bug behind #345 (and supersedes the stale-cache hypothesis — this is a real mapping bug, reproduced locally with fresh data).

## Bugs fixed (all in `buildContacts`, `frontend/src/lib/schemes.ts`)

1. **Contacts dropped when fields are plain strings.** `maxContacts` only counted array lengths, so for schemes whose `phone`/`email`/`address` are strings (the common case) it computed `0` and returned a planning-area-only card — discarding phone, email, and the full address. Now a non-empty string counts as 1.
2. **Literal "NO LOCATION" cards.** `planning_area` arrays containing the `"No Location"` placeholder rendered cards labeled "NO LOCATION". Now normalized everywhere via `cleanPlanningArea` — the contact still renders (phone/address), just without a bogus location label.
3. **Junk placeholder emails.** Some scraped sources store `"This email address is being protected from spambots..."` as the email. Added `cleanEmails`/`isRealEmail` to drop anything that isn't a plausible address, so it never renders as a broken mailto.

## Verified locally (emulator + browser)

- APSN (planning area + string contacts) → address + phone + email ✅
- Tuition (`['No Location','No Location']` + phones + junk email) → 2 cards with address+phones, no "NO LOCATION", no spambot junk ✅
- PD Concession Card (planning area, no contact) → location-only card (intended) ✅
- IT Literacy (No Location + phone/email) → phone + email, no label ✅

`tsc` passes; staging build compiles + type-checks (page-data step fails only on the local missing Firebase key, as expected).

## Related

- Backend data-quality follow-up (junk scraped emails) filed separately.
- Closes #343
- Closes #345

