### PR TITLE
fix: guard navbar chat reset

### DIFF
--- a/frontend/src/components/chat/chat-page.tsx
+++ b/frontend/src/components/chat/chat-page.tsx
@@ -37,6 +37,8 @@ export default function ChatPage() {
     setShowQuickReplies,
     draftMessage,
     setDraftMessage,
+    resetModalIsOpen,
+    setResetModalIsOpen,
   } = useChat();
 
   const [isGenerating, setIsGenerating] = useState(
@@ -45,7 +47,6 @@ export default function ChatPage() {
   const [statusSteps, setStatusSteps] = useState<StatusStep[]>([]);
   const statusStepsRef = useRef<StatusStep[]>([]);
   const [streamError, setStreamError] = useState<string | null>(null);
-  const [resetModalIsOpen, setResetModalIsOpen] = useState(false);
   const [streamingBlocks, setStreamingBlocks] = useState<string[]>([]);
   const streamingBlocksRef = useRef<string[]>([]);
   // Mobile-only Tabs selection (desktop shows chat + schemes side by side).
@@ -415,6 +416,7 @@ export default function ChatPage() {
     setDraftMessage("");
     setIsGenerating(false);
     setShowQuickReplies(false);
+    setResetModalIsOpen(false);
   };
 
   // pulse schemes tab in mobile view when schemes list updated

--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { MouseEvent, useEffect, useState } from "react";
 import { Menu, X, ArrowRight } from "lucide-react";
 import { AnimatePresence, motion } from "framer-motion";
 import { Button } from "@/components/landing/ui/button";
@@ -17,6 +17,7 @@ import {
   motionPreset,
   transition,
 } from "@/lib/design-system/motion";
+import { useChat } from "@/providers";
 
 type NavLink = {
   label: string;
@@ -27,6 +28,7 @@ type NavLink = {
 export function Navbar() {
   const { t } = useLanguage();
   const pathname = usePathname();
+  const { hasActiveChat, setResetModalIsOpen } = useChat();
   const [mobileOpen, setMobileOpen] = useState(false);
   const { isHidden: mobileHidden, isScrolled: scrolled } = useHideOnScroll({
     disabled: mobileOpen,
@@ -61,6 +63,15 @@ export function Navbar() {
     };
   }, [mobileHidden, mobileOpen]);
 
+  const handleSearchEntryClick = (event: MouseEvent<Element>) => {
+    setMobileOpen(false);
+
+    if (pathname === "/" && hasActiveChat) {
+      event.preventDefault();
+      setResetModalIsOpen(true);
+    }
+  };
+
   return (
     <header
       className={cn(
@@ -78,6 +89,7 @@ export function Navbar() {
         {/* Logo */}
         <a
           href="/"
+          onClick={handleSearchEntryClick}
           className="flex items-center gap-2 font-serif text-xl tracking-tight cursor-pointer"
         >
           <Image
@@ -113,7 +125,12 @@ export function Navbar() {
                       "aria-disabled:text-neutral-300 aria-disabled:cursor-default",
                     )}
                   >
-                    <Link href={link.href}>
+                    <Link
+                      href={link.href}
+                      onClick={
+                        link.href === "/" ? handleSearchEntryClick : undefined
+                      }
+                    >
                       {link.label}
                       {link.href === "/" && (
                         <ArrowRight className="inline h-3.5 w-3.5 ml-1.5" />
@@ -187,6 +204,7 @@ export function Navbar() {
               <Link href="/">
                 <Button
                   size="sm"
+                  onClick={handleSearchEntryClick}
                   className={cn(
                     "min-h-11 w-full cursor-pointer gap-1.5 rounded-full font-semibold",
                     selectedKey === "/"

--- a/frontend/src/providers/chat-provider.tsx
+++ b/frontend/src/providers/chat-provider.tsx
@@ -37,8 +37,11 @@ export type QuickReplySuggestion = {
 };
 
 type ChatContextType = {
+  hasActiveChat: boolean;
   messages: Message[];
   setMessages: React.Dispatch<React.SetStateAction<Message[]>>;
+  resetModalIsOpen: boolean;
+  setResetModalIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
   sessionId: string;
   setSessionId: React.Dispatch<React.SetStateAction<string>>;
   schemes: Scheme[];
@@ -75,6 +78,7 @@ function parseQuickReplies(value: string | null): QuickReplySuggestion[] {
 
 export const ChatProvider = ({ children }: { children: ReactNode }) => {
   const [messages, setMessages] = useState<Message[]>([]);
+  const [resetModalIsOpen, setResetModalIsOpen] = useState(false);
   const [schemes, setSchemes] = useState<Scheme[]>([]);
   const [sessionId, setSessionId] = useState("");
   const [quickReplies, setQuickReplies] = useState<QuickReplySuggestion[]>([]);
@@ -171,8 +175,11 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
   return (
     <ChatContext.Provider
       value={{
+        hasActiveChat: messages.length > 0,
         messages,
         setMessages,
+        resetModalIsOpen,
+        setResetModalIsOpen,
         schemes,
         setSchemes,
         sessionId,


### PR DESCRIPTION
Chat
- Open the existing reset modal when users click the logo or Search schemes nav button while already in an active base-route chat
- Keep normal navigation to `/` from non-chat routes or when no active chat exists

**Link to Issue:**

#353 