### PR TITLE
fix: reset chat from navbar logo and Search Schemes on base route

### DIFF
--- a/frontend/src/components/chat/chat-page.tsx
+++ b/frontend/src/components/chat/chat-page.tsx
@@ -37,6 +37,8 @@ export default function ChatPage() {
     setShowQuickReplies,
     draftMessage,
     setDraftMessage,
+    resetModalIsOpen,
+    setResetModalIsOpen,
   } = useChat();
 
   const [isGenerating, setIsGenerating] = useState(
@@ -45,7 +47,6 @@ export default function ChatPage() {
   const [statusSteps, setStatusSteps] = useState<StatusStep[]>([]);
   const statusStepsRef = useRef<StatusStep[]>([]);
   const [streamError, setStreamError] = useState<string | null>(null);
-  const [resetModalIsOpen, setResetModalIsOpen] = useState(false);
   const [streamingBlocks, setStreamingBlocks] = useState<string[]>([]);
   const streamingBlocksRef = useRef<string[]>([]);
   // Mobile-only Tabs selection (desktop shows chat + schemes side by side).

--- a/frontend/src/components/layout/navbar.tsx
+++ b/frontend/src/components/layout/navbar.tsx
@@ -12,6 +12,7 @@ import { usePathname } from "next/navigation";
 import { Tabs } from "@heroui/react";
 import Image from "next/image";
 import { useHideOnScroll } from "@/hooks/use-hide-on-scroll";
+import { useChat } from "@/providers";
 import {
   cssTransition,
   motionPreset,
@@ -27,7 +28,22 @@ type NavLink = {
 export function Navbar() {
   const { t } = useLanguage();
   const pathname = usePathname();
+  const { messages, setResetModalIsOpen } = useChat();
   const [mobileOpen, setMobileOpen] = useState(false);
+
+  // On the base route with an active chat, the logo / "Search Schemes" are the
+  // natural "back to search" actions — but they'd silently wipe the session.
+  // Intercept them and open the reset confirmation instead. Off-route, let the
+  // link navigate to "/" as normal.
+  const handleSearchSchemesPress = (
+    event: React.MouseEvent<HTMLAnchorElement>,
+  ) => {
+    setMobileOpen(false);
+    if (pathname === "/" && messages.length > 0) {
+      event.preventDefault();
+      setResetModalIsOpen(true);
+    }
+  };
   const { isHidden: mobileHidden, isScrolled: scrolled } = useHideOnScroll({
     disabled: mobileOpen,
     resetKey: pathname,
@@ -78,6 +94,7 @@ export function Navbar() {
         {/* Logo */}
         <a
           href="/"
+          onClick={handleSearchSchemesPress}
           className="flex items-center gap-2 font-serif text-xl tracking-tight cursor-pointer"
         >
           <Image
@@ -113,7 +130,14 @@ export function Navbar() {
                       "aria-disabled:text-neutral-300 aria-disabled:cursor-default",
                     )}
                   >
-                    <Link href={link.href}>
+                    <Link
+                      href={link.href}
+                      onClick={
+                        link.href === "/"
+                          ? handleSearchSchemesPress
+                          : undefined
+                      }
+                    >
                       {link.label}
                       {link.href === "/" && (
                         <ArrowRight className="inline h-3.5 w-3.5 ml-1.5" />
@@ -184,7 +208,7 @@ export function Navbar() {
               <LanguageToggle />
             </div>
             <div className="mt-3 flex justify-center">
-              <Link href="/">
+              <Link href="/" onClick={handleSearchSchemesPress}>
                 <Button
                   size="sm"
                   className={cn(

--- a/frontend/src/providers/chat-provider.tsx
+++ b/frontend/src/providers/chat-provider.tsx
@@ -49,6 +49,8 @@ type ChatContextType = {
   setShowQuickReplies: React.Dispatch<React.SetStateAction<boolean>>;
   draftMessage: string;
   setDraftMessage: React.Dispatch<React.SetStateAction<string>>;
+  resetModalIsOpen: boolean;
+  setResetModalIsOpen: React.Dispatch<React.SetStateAction<boolean>>;
 };
 
 const ChatContext = createContext<ChatContextType | undefined>(undefined);
@@ -80,6 +82,7 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
   const [quickReplies, setQuickReplies] = useState<QuickReplySuggestion[]>([]);
   const [showQuickReplies, setShowQuickReplies] = useState(false);
   const [draftMessage, setDraftMessage] = useState("");
+  const [resetModalIsOpen, setResetModalIsOpen] = useState(false);
   const [isInitialized, setIsInitialized] = useState(false);
 
   useEffect(() => {
@@ -183,6 +186,8 @@ export const ChatProvider = ({ children }: { children: ReactNode }) => {
         setShowQuickReplies,
         draftMessage,
         setDraftMessage,
+        resetModalIsOpen,
+        setResetModalIsOpen,
       }}
     >
       {children}


### PR DESCRIPTION
Closes #353

## Problem
On `/` with an active chat, clicking the **Schemes.sg logo** or **Search Schemes** silently wiped the session — they looked like a "back to search" action but had no confirmation.

## Fix
Lifted the reset-modal open state (`resetModalIsOpen`/`setResetModalIsOpen`) into `ChatProvider` so the sibling `Navbar` can open the *existing* confirmation modal (no duplicate modal, no duplicated `handleReset`).

Navbar logo + desktop tab + mobile button now share one `handleSearchSchemesPress`:
- On `/` **with** an active session (`messages.length > 0`) → `preventDefault` + open the reset modal.
- Off-route, or no active session → navigate to `/` as before.

`ChatPage` now reads the modal state from context instead of local `useState`; New Chat button behaviour is unchanged.

## Files
- `providers/chat-provider.tsx` — expose reset-modal state
- `components/chat/chat-page.tsx` — consume it from context
- `components/layout/navbar.tsx` — intercept logo / Search Schemes on base route

## Validation (Chrome DevTools MCP, seeded active session)
| Behavior | Result |
|---|---|
| Logo on `/` + active session → reset modal | ✅ |
| Cancel → modal closes, session survives | ✅ |
| Confirm → session cleared, lands on ChatLanding, sessionStorage emptied | ✅ |
| Logo on `/about` + active session → redirect to `/`, no modal | ✅ |
| Desktop "Search Schemes" tab on `/` → reset modal | ✅ |
| Existing "New chat" button → same modal (unchanged) | ✅ |

No console errors/warnings. Consistent across desktop + mobile navbar.