### PR TITLE
fix: decode Cloudflare-protected emails in scraper (#347)

### DIFF
--- a/backend/scheme-processor/app/services/cfemail.py
+++ b/backend/scheme-processor/app/services/cfemail.py
@@ -1,0 +1,64 @@
+"""Decode Cloudflare-obfuscated emails (data-cfemail)."""
+import re
+from typing import List
+
+# Pattern to find Cloudflare-protected emails in HTML
+CFEMAIL_HEX = re.compile(
+    r'(?:data-cfemail="|/cdn-cgi/l/email-protection#)([0-9a-fA-F]{4,})'
+)
+
+
+def decode_cfemail(hex_str: str) -> str:
+    """
+    Decode a Cloudflare cfemail hex string.
+    
+    How it works:
+    - First byte of hex is the XOR key
+    - Rest of the bytes are XOR-encoded with that key
+    - We reverse the XOR to get the real email
+    
+    Args:
+        hex_str: The hex string from data-cfemail attribute
+        
+    Returns:
+        The decoded email address (e.g., "info@charity.org")
+    """
+    # Convert hex string to bytes
+    data = bytes.fromhex(hex_str)
+    
+    # First byte is the key
+    key = data[0]
+    
+    # XOR every other byte with the key to decode
+    decoded_bytes = bytes(b ^ key for b in data[1:])
+    
+    # Convert bytes back to text
+    return decoded_bytes.decode("utf-8")
+
+
+def extract_cf_protected_emails(html: str) -> List[str]:
+    """
+    Find and decode all Cloudflare-protected emails in raw HTML.
+    
+    Args:
+        html: Raw HTML source code
+        
+    Returns:
+        List of decoded email addresses, with duplicates removed
+    """
+    emails = []
+    
+    # Find all matches of the hex pattern
+    for match in CFEMAIL_HEX.finditer(html):
+        try:
+            # Try to decode this match
+            decoded = decode_cfemail(match.group(1))
+            
+            # Only add if it looks like an email and we haven't seen it before
+            if "@" in decoded and decoded not in emails:
+                emails.append(decoded)
+        except (ValueError, UnicodeDecodeError):
+            # If decoding fails, just skip this one
+            continue
+    
+    return emails

--- a/backend/scheme-processor/app/services/extraction.py
+++ b/backend/scheme-processor/app/services/extraction.py
@@ -20,6 +20,15 @@ GENERIC_EMAIL_PREFIXES = {"user@", "example@", "test@", "name@", "email@", "your
 def is_generic_email(email: str) -> bool:
     """Check if an email is a generic/placeholder address."""
     email_lower = email.lower().strip()
+
+    # Reject Cloudflare placeholder text
+    if any(phrase in email_lower for phrase in [
+        "protected from spambots",
+        "email protected",
+        "cloudflare",
+    ]):
+        return True
+
     domain = email_lower.split("@")[-1] if "@" in email_lower else ""
     if domain in GENERIC_EMAIL_DOMAINS:
         return True

--- a/backend/scheme-processor/app/services/scraper.py
+++ b/backend/scheme-processor/app/services/scraper.py
@@ -13,6 +13,7 @@ from typing import Any, Dict, List
 import requests
 from app.constants import BOT_PROTECTION_INDICATORS, CLOUDFLARE_INDICATORS
 from app.services.extraction import select_best_logo
+from app.services.cfemail import extract_cf_protected_emails
 from loguru import logger
 
 
@@ -159,6 +160,14 @@ def _process_crawl_results(results, url: str) -> Dict[str, Any]:
                     all_images.extend(images)
 
         scraped_text = "\n\n---PAGE BREAK---\n\n".join(all_text)
+
+        # Decode any Cloudflare-protected emails from raw HTML
+        for result in results:
+            if hasattr(result, 'html') and result.html:
+                cf_emails = extract_cf_protected_emails(result.html)
+                if cf_emails:
+                    scraped_text += "\n" + " ".join(cf_emails)
+
         logo_url = select_best_logo(all_images, url) if all_images else None
 
         return {"content": scraped_text, "images": all_images, "logo_url": logo_url, "error": None}
@@ -169,6 +178,13 @@ def _process_crawl_results(results, url: str) -> Dict[str, Any]:
         return {"content": "", "images": [], "logo_url": None, "error": error_msg}
 
     scraped_text = results.markdown or results.cleaned_html or ""
+
+    # Decode any Cloudflare-protected emails from raw HTML
+    if hasattr(results, 'html') and results.html:
+        cf_emails = extract_cf_protected_emails(results.html)
+        if cf_emails:
+            scraped_text += "\n" + " ".join(cf_emails)
+
     images = []
     logo_url = None
 

--- a/backend/scheme-processor/tests/unit/test_cfemail.py
+++ b/backend/scheme-processor/tests/unit/test_cfemail.py
@@ -1,0 +1,74 @@
+"""Tests for Cloudflare email decoder."""
+import pytest
+from app.services.cfemail import decode_cfemail, extract_cf_protected_emails
+
+
+class TestDecodeCfemail:
+    """Test the decode_cfemail function."""
+
+    def test_decode_cfemail_simple(self):
+        """Test decoding a known Cloudflare hex string."""
+        # This hex decodes to "info@better.sg"
+        hex_str = "d6bfb8b0b996b4b3a2a2b3a4f8a5b1"
+        result = decode_cfemail(hex_str)
+        assert result == "info@better.sg"
+
+    def test_decode_cfemail_invalid_hex(self):
+        """Test that invalid hex raises ValueError."""
+        with pytest.raises(ValueError):
+            decode_cfemail("zzzz")
+
+    def test_decode_cfemail_invalid_utf8(self):
+        """Test that invalid UTF-8 raises UnicodeDecodeError."""
+        # Create hex that decodes to invalid UTF-8
+        with pytest.raises(UnicodeDecodeError):
+            decode_cfemail("00ff")
+
+
+class TestExtractCfProtectedEmails:
+    """Test the extract_cf_protected_emails function."""
+
+    def test_extract_from_cdn_cgi_link(self):
+        """Test extracting email from /cdn-cgi/l/email-protection# format."""
+        html = 'href="/cdn-cgi/l/email-protection#d6bfb8b0b996b4b3a2a2b3a4f8a5b1"'
+        result = extract_cf_protected_emails(html)
+        assert "info@better.sg" in result
+
+    def test_extract_from_data_attribute(self):
+        """Test extracting email from data-cfemail attribute."""
+        html = '<a data-cfemail="d6bfb8b0b996b4b3a2a2b3a4f8a5b1">[email protected]</a>'
+        result = extract_cf_protected_emails(html)
+        assert "info@better.sg" in result
+
+    def test_no_duplicates(self):
+        """Test that same email appearing twice is only returned once."""
+        html = '''
+            <a data-cfemail="d6bfb8b0b996b4b3a2a2b3a4f8a5b1">[email protected]</a>
+            <a href="/cdn-cgi/l/email-protection#d6bfb8b0b996b4b3a2a2b3a4f8a5b1">Contact</a>
+        '''
+        result = extract_cf_protected_emails(html)
+        assert result.count("info@better.sg") == 1
+
+    def test_empty_html(self):
+        """Test with empty HTML."""
+        result = extract_cf_protected_emails("")
+        assert result == []
+
+    def test_no_cloudflare_emails(self):
+        """Test with HTML that has no Cloudflare emails."""
+        html = '<p>Just plain text, no emails here</p>'
+        result = extract_cf_protected_emails(html)
+        assert result == []
+
+    def test_multiple_different_emails(self):
+        """Test extracting multiple different emails."""
+        # Note: In reality, finding different CF emails requires different hex strings
+        # For now, we test with the same email in different formats
+        html = '''
+            <a data-cfemail="d6bfb8b0b996b4b3a2a2b3a4f8a5b1">[email protected]</a>
+            <p>Some other content</p>
+            <a href="/cdn-cgi/l/email-protection#d6bfb8b0b996b4b3a2a2b3a4f8a5b1">Contact</a>
+        '''
+        result = extract_cf_protected_emails(html)
+        assert len(result) == 1  # Same email, so only 1 unique
+        assert "info@better.sg" in result


### PR DESCRIPTION
## Problem
Schemes.sg stores "protected from spambots" placeholder text instead of real emails when websites use Cloudflare email obfuscation.

## Root Cause
Cloudflare hides email addresses in the `data-cfemail` attribute as XOR-encoded hex strings. The real email only exists in raw HTML, not in the rendered markdown that the scraper processes.

## Solution
- Added `cfemail.py` module to decode Cloudflare hex strings
- Integrated decoder into `_process_crawl_results()` in scraper.py
- Updated `is_generic_email()` to filter out placeholder text
- Added comprehensive unit tests

## Testing
All unit tests pass:
```bash
pytest tests/unit/test_cfemail.py -v
```

Fixes #347